### PR TITLE
[GH#10] Export behaviours/snappable & behaviours/collidable

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -3,12 +3,18 @@ import Sortable from './sortable';
 import Swappable from './swappable';
 import Droppable from './droppable';
 import AbstractEvent from './events/abstract-event';
+import Snappable from './behaviour/snappable';
+import Collidable from './behaviour/collidable';
 
-export {Draggable};
-export {Sortable};
-export {Swappable};
-export {Droppable};
-export {AbstractEvent};
+export {
+  Draggable,
+  Sortable,
+  Swappable,
+  Droppable,
+  Snappable,
+  Collidable,
+  AbstractEvent,
+};
 
 export function createEventClass(options) {
   function EventConstructor() { return null; }


### PR DESCRIPTION
Resolves #10.

`yarn lint` passes
`yarn test` passes (9/9 tests)

`yarn test-ci` shows that there's a lot of missing coverage as I'm sure everyone is aware.


Questions: 
- Is one-export-per-line a Shopify code style rule? Should I revert the change that exports them all together?
- Would it be valuable to add a test that asserts that each of these modules is exported from the main `index.js`?


Cheers~