### PR TITLE
Fix README errors relating to the Droppable API

### DIFF
--- a/README.md
+++ b/README.md
@@ -227,9 +227,7 @@ new Sortable(document.querySelectorAll('ul'))
 ## Droppable
 
 Droppable allows you to declare draggable and droppable elements via options.
-
-Sortable allows you to reorder elements. It maintains the order internally and fires
-three events on top of the draggable events: `sortable:start`, `sortable:sorted` and `sortable:stop`.
+Droppable fires two events on top of the draggable events: `droppable:over` and `droppable:out`.
 
 ### API
 


### PR DESCRIPTION
I noticed an error in the README in the section about the Droppable API. Here's the fix!

Introductory paragraph fixed to display the correct additional events that Droppable emits.