### PR TITLE
Add CDN link

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,12 @@ or via yarn:
 yarn add @shopify/draggable
 ```
 
+or via CDN
+
+```
+<script src="https://cdn.jsdelivr.net/npm/@shopify/draggable@1.0.0-beta/lib/draggable.js"></script>
+```
+
 ## Draggable
 
 ### API


### PR DESCRIPTION
I added a [jsDelivr CDN link](https://www.jsdelivr.com/package/npm/@shopify/draggable) to your readme, so that people can use files directly without downloading them. jsDelivr is the fastest opensource CDN available and built specifically for production usage.