### PR TITLE
make README.md more clear 💅

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ A css selector for draggable elements within the `containers` specified. By defa
 look for an element with `.draggable-source` class. Default: `.draggable-source`
 
 **`handle {String}`**  
-Specify a `.css` selector for a handle element if you don't want to allow drag action
+Specify a `css` selector for a handle element if you don't want to allow drag action
 on the entire element. Default: `null`
 
 **`delay {Number}`**  
@@ -115,7 +115,7 @@ If you want to delay a `drag:start` you can specify delay in milliseconds. This 
 for draggable elements within scrollable containers. Default: `0`
 
 **`native {Boolean}`**  
-If enabled Draggable will use the browsers native drag events to detect drag behaviour. By default
+If enabled, Draggable will use the browsers native drag events to detect drag behaviour. By default
 it will use mouse events to detect drag behaviour. You can only customize the mirror element when
 using mouse events, otherwise mirror will be `null` in events. Default: `false`
 

--- a/README.md
+++ b/README.md
@@ -107,11 +107,11 @@ A css selector for draggable elements within the `containers` specified. By defa
 look for an element with `.draggable-source` class. Default: `.draggable-source`
 
 **`handle {String}`**  
-Specify a css selector for a handle element if you don't want to allow drag action
+Specify a `.css` selector for a handle element if you don't want to allow drag action
 on the entire element. Default: `null`
 
 **`delay {Number}`**  
-If you want to delay a drag start you can specify delay in milliseconds. This can be useful
+If you want to delay a `drag:start` you can specify delay in milliseconds. This can be useful
 for draggable elements within scrollable containers. Default: `0`
 
 **`native {Boolean}`**  


### PR DESCRIPTION
I changed README.md on line 110 and 114 to:

- Specify a `css` selector 

- If you want to delay a `drag:start` 