### PR TITLE
Fix anchor link in Readme TOC

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ interface, for more information read the documentation below.
 ## Table of Contents
 
 * [Install](#Install)
-* [Draggable](#draggable-1)
+* [Draggable](#draggable)
   * [API](#api)
   * [Options](#options)
   * [Events](#events)


### PR DESCRIPTION
Fixes the `Draggable` link in the TOC to link to the correct anchor tag within the readme.