### PR TITLE
Fix touch event issues

### DIFF
--- a/src/behaviour/snappable.js
+++ b/src/behaviour/snappable.js
@@ -38,7 +38,7 @@ export default class Snappable {
       return;
     }
 
-    this.firstSource = event.source;
+    this.firstSource = event.movableSource;
   }
 
   _onDragStop() {
@@ -50,7 +50,7 @@ export default class Snappable {
       return;
     }
 
-    const source = event.source || event.dragEvent.source;
+    const source = event.movableSource || event.dragEvent.source;
     const mirror = event.mirror || event.dragEvent.mirror;
 
     if (source === this.firstSource) {
@@ -86,7 +86,7 @@ export default class Snappable {
     }
 
     const mirror = event.mirror || event.dragEvent.mirror;
-    const source = event.source || event.dragEvent.source;
+    const source = event.movableSource || event.dragEvent.source;
 
     const snapOutEvent = new SnapOutEvent({
       dragEvent: event,

--- a/src/draggable.js
+++ b/src/draggable.js
@@ -206,6 +206,8 @@ export default class Draggable {
 
     this.dragging = true;
 
+    this.movableSource = this.source.cloneNode(true);
+
     if (!isDragEvent(originalEvent)) {
       const appendableContainer = this.getAppendableContainer({source: this.source});
       this.mirror = this.source.cloneNode(true);
@@ -229,6 +231,14 @@ export default class Draggable {
       this.triggerEvent(mirrorAttachedEvent);
     }
 
+    this.source.parentNode.insertBefore(this.movableSource, this.source);
+
+    const source = this.source;
+
+    setTimeout(() => {
+      source.style.display = 'none';
+    }, 0);
+
     this.source.classList.add(this.getClassNameFor('source:dragging'));
     this.sourceContainer.classList.add(this.getClassNameFor('container:dragging'));
     document.body.classList.add(this.getClassNameFor('body:dragging'));
@@ -237,6 +247,7 @@ export default class Draggable {
       const mirrorMoveEvent = new MirrorMoveEvent({
         source: this.source,
         mirror: this.mirror,
+        movableSource: this.movableSource,
         sourceContainer: container,
         sensorEvent,
       });
@@ -250,6 +261,7 @@ export default class Draggable {
     const dragEvent = new DragStartEvent({
       source: this.source,
       mirror: this.mirror,
+      movableSource: this.movableSource,
       sourceContainer: container,
       sensorEvent,
     });
@@ -281,6 +293,7 @@ export default class Draggable {
     const dragMoveEvent = new DragMoveEvent({
       source: this.source,
       mirror: this.mirror,
+      movableSource: this.movableSource,
       sourceContainer: container,
       sensorEvent,
     });
@@ -295,6 +308,7 @@ export default class Draggable {
       const mirrorMoveEvent = new MirrorMoveEvent({
         source: this.source,
         mirror: this.mirror,
+        movableSource: this.movableSource,
         sourceContainer: container,
         sensorEvent,
       });
@@ -313,6 +327,7 @@ export default class Draggable {
       const dragOutEvent = new DragOutEvent({
         source: this.source,
         mirror: this.mirror,
+        movableSource: this.movableSource,
         sourceContainer: container,
         sensorEvent,
         over: this.currentOver,
@@ -328,6 +343,7 @@ export default class Draggable {
       const dragOutContainerEvent = new DragOutContainerEvent({
         source: this.source,
         mirror: this.mirror,
+        movableSource: this.movableSource,
         sourceContainer: container,
         sensorEvent,
         overContainer: this.overContainer,
@@ -345,6 +361,7 @@ export default class Draggable {
       const dragOverContainerEvent = new DragOverContainerEvent({
         source: this.source,
         mirror: this.mirror,
+        movableSource: this.movableSource,
         sourceContainer: container,
         sensorEvent,
         overContainer,
@@ -361,6 +378,7 @@ export default class Draggable {
       const dragOverEvent = new DragOverEvent({
         source: this.source,
         mirror: this.mirror,
+        movableSource: this.movableSource,
         sourceContainer: container,
         sensorEvent,
         overContainer,
@@ -380,11 +398,16 @@ export default class Draggable {
     const dragStopEvent = new DragStopEvent({
       source: this.source,
       mirror: this.mirror,
+      movableSource: this.movableSource,
       sensorEvent: event.sensorEvent,
       sourceContainer: this.sourceContainer,
     });
 
     this.triggerEvent(dragStopEvent);
+
+    this.movableSource.parentNode.insertBefore(this.source, this.movableSource);
+    this.movableSource.parentNode.removeChild(this.movableSource);
+    this.source.style.display = '';
 
     this.source.classList.remove(this.getClassNameFor('source:dragging'));
     this.source.classList.add(this.getClassNameFor('source:placed'));
@@ -430,6 +453,7 @@ export default class Draggable {
 
     this.source = null;
     this.mirror = null;
+    this.movableSource = null;
     this.currentOverContainer = null;
     this.currentOver = null;
     this.sourceContainer = null;

--- a/src/droppable.js
+++ b/src/droppable.js
@@ -122,7 +122,7 @@ export default class Droppable {
       this.lastDroppable.classList.remove(occupiedClass);
     }
 
-    droppable.appendChild(event.source);
+    droppable.appendChild(event.movableSource);
     droppable.classList.add(occupiedClass);
 
     return true;
@@ -140,7 +140,7 @@ export default class Droppable {
       return;
     }
 
-    this.initialDroppable.appendChild(event.source);
+    this.initialDroppable.appendChild(event.movableSource);
     this.lastDroppable.classList.remove(this.getClassNameFor('droppable:occupied'));
   }
 

--- a/src/events/drag-event.js
+++ b/src/events/drag-event.js
@@ -5,6 +5,10 @@ export class DragEvent extends AbstractEvent {
     return this.data.source;
   }
 
+  get movableSource() {
+    return this.data.movableSource;
+  }
+
   get mirror() {
     return this.data.mirror;
   }

--- a/src/events/mirror-event.js
+++ b/src/events/mirror-event.js
@@ -5,6 +5,10 @@ export class MirrorEvent extends AbstractEvent {
     return this.data.source;
   }
 
+  get movableSource() {
+    return this.data.movableSource;
+  }
+
   get mirror() {
     return this.data.mirror;
   }

--- a/src/sortable.js
+++ b/src/sortable.js
@@ -61,7 +61,7 @@ export default class Sortable {
       return;
     }
 
-    const moves = move(event.source, event.over, event.overContainer);
+    const moves = move(event.movableSource, event.over, event.overContainer);
 
     if (!moves) {
       return;
@@ -76,11 +76,11 @@ export default class Sortable {
   }
 
   _onDragOver(event) {
-    if (event.over === event.source) {
+    if (event.over === event.movableSource) {
       return;
     }
 
-    const moves = move(event.source, event.over, event.overContainer);
+    const moves = move(event.movableSource, event.over, event.overContainer);
 
     if (!moves) {
       return;

--- a/src/swappable.js
+++ b/src/swappable.js
@@ -51,13 +51,13 @@ export default class Swappable {
   }
 
   _onDragOver(event) {
-    if (event.over === event.source || event.canceled()) {
+    if (event.over === event.movableSource || event.canceled()) {
       return;
     }
 
     // swap originally swapped element back
     if (this.lastOver && this.lastOver !== event.over) {
-      swap(this.lastOver, event.source);
+      swap(this.lastOver, event.movableSource);
     }
 
     if (this.lastOver === event.over) {
@@ -66,7 +66,7 @@ export default class Swappable {
       this.lastOver = event.over;
     }
 
-    swap(event.source, event.over);
+    swap(event.movableSource, event.over);
 
     // Let this cancel the actual swap
     const swappableSwappedEvent = new SwappableSwappedEvent({


### PR DESCRIPTION
Fixes: https://github.com/Shopify/draggable/issues/40

Instead of moving the actual source element around, we need to create a copy (`movableSource`) that can safely be moved around the DOM, without touch events freezing up

This PR will be followed with performance improvements