### PR TITLE
Announce plugin for screen readers

### DIFF
--- a/src/Draggable/Plugins/Announcement/Announcement.js
+++ b/src/Draggable/Plugins/Announcement/Announcement.js
@@ -1,0 +1,179 @@
+import AbstractPlugin from 'shared/AbstractPlugin';
+
+const onInitialize = Symbol('onInitialize');
+const onDestroy = Symbol('onDestroy');
+const announceEvent = Symbol('announceEvent');
+const announceMessage = Symbol('announceMessage');
+
+const ARIA_RELEVANT = 'aria-relevant';
+const ARIA_ATOMIC = 'aria-atomic';
+const ARIA_LIVE = 'aria-live';
+const ROLE = 'role';
+
+/**
+ * Announcement default options
+ * @property {Object} defaultOptions
+ * @property {Number} defaultOptions.expire
+ * @type {Object}
+ */
+export const defaultOptions = {
+  expire: 7000,
+};
+
+/**
+ * Announcement plugin
+ * @class Announcement
+ * @module Announcement
+ * @extends AbstractPlugin
+ */
+export default class Announcement extends AbstractPlugin {
+
+  /**
+   * Announcement constructor.
+   * @constructs Announcement
+   * @param {Draggable} draggable - Draggable instance
+   */
+  constructor(draggable) {
+    super(draggable);
+
+    /**
+     * Plugin options
+     * @property options
+     * @type {Object}
+     */
+    this.options = {
+      ...defaultOptions,
+      ...this.getOptions(),
+    };
+
+    /**
+     * Original draggable trigger method. Hack until we have onAll or on('all')
+     * @property originalTriggerMethod
+     * @type {Function}
+     */
+    this.originalTriggerMethod = this.draggable.trigger;
+
+    this[onInitialize] = this[onInitialize].bind(this);
+    this[onDestroy] = this[onDestroy].bind(this);
+  }
+
+  /**
+   * Attaches listeners to draggable
+   */
+  attach() {
+    this.draggable
+      .on('draggable:initialize', this[onInitialize]);
+  }
+
+  /**
+   * Detaches listeners from draggable
+   */
+  detach() {
+    this.draggable
+      .off('draggable:destroy', this[onDestroy]);
+  }
+
+  /**
+   * Returns passed in options
+   */
+  getOptions() {
+    return this.draggable.options.announcements || {};
+  }
+
+  /**
+   * Announces event
+   * @private
+   * @param {AbstractEvent} event
+   */
+  [announceEvent](event) {
+    const message = this.options[event.type];
+
+    if (message && (typeof message === 'string')) {
+      this[announceMessage](message);
+    }
+
+    if (message && (typeof message === 'function')) {
+      this[announceMessage](message(event));
+    }
+  }
+
+  /**
+   * Announces message to screen reader
+   * @private
+   * @param {String} message
+   */
+  [announceMessage](message) {
+    announce(message, {expire: this.options.expire});
+  }
+
+  /**
+   * Initialize hander
+   * @private
+   */
+  [onInitialize]() {
+    // Hack until there is an api for listening for all events
+    this.draggable.trigger = (event) => {
+      try {
+        this[announceEvent](event);
+      } finally {
+        // Ensure that original trigger is called
+        this.originalTriggerMethod.call(this.draggable, event);
+      }
+    };
+  }
+
+  /**
+   * Destroy hander
+   * @private
+   */
+  [onDestroy]() {
+    this.draggable.trigger = this.originalTriggerMethod;
+  }
+}
+
+/**
+ * @const {HTMLElement} liveRegion
+ */
+const liveRegion = createRegion();
+
+/**
+ * Announces message via live region
+ * @param {String} message
+ * @param {Object} options
+ * @param {Number} options.expire
+ */
+function announce(message, {expire}) {
+  const element = document.createElement('div');
+  element.innerHTML = message;
+  liveRegion.appendChild(element);
+  return setTimeout(() => {
+    liveRegion.removeChild(element);
+  }, expire);
+}
+
+/**
+ * Creates region element
+ * @return {HTMLElement}
+ */
+function createRegion() {
+  const element = document.createElement('div');
+
+  element.setAttribute('id', 'draggable-live-region');
+  element.setAttribute(ARIA_RELEVANT, 'additions');
+  element.setAttribute(ARIA_ATOMIC, 'true');
+  element.setAttribute(ARIA_LIVE, 'assertive');
+  element.setAttribute(ROLE, 'log');
+
+  element.style.position = 'fixed';
+  element.style.width = '1px';
+  element.style.height = '1px';
+  element.style.top = '-1px';
+  element.style.overflow = 'hidden';
+
+  return element;
+}
+
+// Append live region element as early as possible
+document.addEventListener('DOMContentLoaded', () => {
+  document.body.appendChild(liveRegion);
+});

--- a/src/Draggable/Plugins/Announcement/README.md
+++ b/src/Draggable/Plugins/Announcement/README.md
@@ -1,0 +1,75 @@
+## Announcement
+
+The Announcement plugin listens to _all_ draggable events and allows you to define announcements via options for events
+that are read back through a screen reader.
+
+### API
+
+**`new Announcement(draggable: Draggable): Announcement`**  
+To create an announcement plugin instance.
+
+### Options
+
+**`expire {Number}`**  
+How long messages should stay inside the live region (in milliseconds). Default: `7000`
+
+**`'drag:start' {String|Function:String}`**  
+Define an announcement on `drag:start`. Default: `Picked up draggable element`
+
+**`'drag:stop' {String|Function:String}`**  
+Define an announcement on `drag:stop`. Default: `Dropped draggable element`
+
+**`'sortable:sorted' {String|Function:String}`**  
+Define an announcement on `sortable:sorted`. No default
+
+**`'swappable:swapped' {String|Function:String}`**  
+Define an announcement on `swappable:swapped`. No default
+
+**`'droppable:dropped' {String|Function:String}`**  
+Define an announcement on `droppable:dropped`. No default
+
+_And any other events you can think of..._
+
+### Examples
+
+#### Static messages
+
+```js
+import {Sortable} from '@shopify/draggable';
+
+const announcements = {
+  'drag:start': 'Draggable element picked up',
+  'drag:stop': 'Draggable element dropped',
+  'sortable:stopped': 'Draggable elements swapped',
+}
+
+const sortable = new Sortable(document.querySelectorAll('ul'), {
+  draggable: 'li',
+  announcements,
+});
+```
+
+#### Dynamic messages
+
+```js
+import {Sortable} from '@shopify/draggable';
+
+const announcements = {
+  'drag:start': (dragEvent) => {
+    return `Picked up ${dragEvent.source.getAttribute('data-name')}`;
+  },
+
+  'drag:stop': (dragEvent) => {
+    return `Dropped ${dragEvent.source.getAttribute('data-name')}`
+  },
+
+  'sortable:sorted': (sortableEvent) => {
+    return `Sorted ${sortableEvent.dragEvent.source.getAttribute('data-name')} with ${sortableEvent.dragEvent.over.getAttribute('data-name')}`;
+  },
+}
+
+const sortable = new Sortable(document.querySelectorAll('ul'), {
+  draggable: 'li',
+  announcements,
+});
+```

--- a/src/Draggable/Plugins/Announcement/index.js
+++ b/src/Draggable/Plugins/Announcement/index.js
@@ -1,0 +1,4 @@
+import Announcement, {defaultOptions} from './Announcement';
+
+export default Announcement;
+export {defaultOptions};

--- a/src/Draggable/Plugins/README.md
+++ b/src/Draggable/Plugins/README.md
@@ -5,3 +5,4 @@ These plugins are included by draggable by default
 - [Accessibility](Accessibility)
 - [Mirror](Mirror)
 - [AutoScroll](AutoScroll)
+- [Announcement](Announcement)

--- a/src/Draggable/Plugins/index.js
+++ b/src/Draggable/Plugins/index.js
@@ -4,6 +4,11 @@ export {
 } from './Mirror';
 
 export {
+  default as Announcement,
+  defaultOptions as defaultAnnouncementOptions,
+} from './Announcement';
+
+export {
   default as AutoScroll,
   defaultOptions as defaultAutoScrollOptions,
 } from './AutoScroll';

--- a/src/Draggable/tests/Draggable.test.js
+++ b/src/Draggable/tests/Draggable.test.js
@@ -23,6 +23,7 @@ import {
   Accessibility,
   Mirror,
   AutoScroll,
+  Announcement,
 } from './../Plugins';
 
 import {
@@ -111,7 +112,7 @@ describe('Draggable', () => {
       const newInstance = new Draggable();
 
       expect(newInstance.plugins.length)
-        .toBe(3);
+        .toBe(4);
 
       expect(newInstance.plugins[0])
         .toBeInstanceOf(Mirror);
@@ -121,6 +122,9 @@ describe('Draggable', () => {
 
       expect(newInstance.plugins[2])
         .toBeInstanceOf(AutoScroll);
+
+      expect(newInstance.plugins[3])
+        .toBeInstanceOf(Announcement);
     });
 
     test('should attach custom plugins', () => {
@@ -131,9 +135,9 @@ describe('Draggable', () => {
       });
 
       expect(newInstance.plugins.length)
-        .toBe(4);
+        .toBe(5);
 
-      const customPlugin = newInstance.plugins[3];
+      const customPlugin = newInstance.plugins[4];
 
       expect(customPlugin.draggable).toBe(newInstance);
 
@@ -207,12 +211,6 @@ describe('Draggable', () => {
 
       newInstance.destroy();
 
-      expect(expectedPlugins[3].detachWasCalled)
-        .toBe(true);
-
-      expect(expectedPlugins[3].numTimesDetachCalled)
-        .toBe(1);
-
       expect(expectedPlugins[4].detachWasCalled)
         .toBe(true);
 
@@ -223,6 +221,12 @@ describe('Draggable', () => {
         .toBe(true);
 
       expect(expectedPlugins[5].numTimesDetachCalled)
+        .toBe(1);
+
+      expect(expectedPlugins[6].detachWasCalled)
+        .toBe(true);
+
+      expect(expectedPlugins[6].numTimesDetachCalled)
         .toBe(1);
     });
 

--- a/src/Droppable/Droppable.js
+++ b/src/Droppable/Droppable.js
@@ -14,12 +14,46 @@ const release = Symbol('release');
 const closestDroppable = Symbol('closestDroppable');
 const getDroppables = Symbol('getDroppables');
 
-const classes = {
+/**
+ * Returns an announcement message when the Draggable element is dropped into a Droppable element
+ * @param {DroppableOverEvent} droppableEvent
+ * @return {String}
+ */
+function onDroppableOverDefaultAnnouncement({dragEvent, droppable}) {
+  const sourceText = dragEvent.source.textContent.trim() || dragEvent.source.id || 'draggable element';
+  const overText = droppable.textContent.trim() || droppable.id || 'droppable element';
+
+  return `Dropped ${sourceText} into ${overText}`;
+}
+
+/**
+ * Returns an announcement message when the Draggable element is released from a Droppable element
+ * @param {DroppableOutEvent} droppableEvent
+ * @return {String}
+ */
+function onDroppableOutDefaultAnnouncement({dragEvent, droppable}) {
+  const sourceText = dragEvent.source.textContent.trim() || dragEvent.source.id || 'draggable element';
+  const overText = droppable.textContent.trim() || droppable.id || 'droppable element';
+
+  return `Released ${sourceText} from ${overText}`;
+}
+
+/**
+ * @const {Object} defaultAnnouncements
+ * @const {Function} defaultAnnouncements['droppable:over']
+ * @const {Function} defaultAnnouncements['droppable:out']
+ */
+const defaultAnnouncements = {
+  'droppable:over': onDroppableOverDefaultAnnouncement,
+  'droppable:out': onDroppableOutDefaultAnnouncement,
+};
+
+const defaultClasses = {
   'droppable:active': 'draggable-droppable--active',
   'droppable:occupied': 'draggable-droppable--occupied',
 };
 
-const defaults = {
+const defaultOptions = {
   droppable: '.draggable-droppable',
 };
 
@@ -39,9 +73,18 @@ export default class Droppable extends Draggable {
    * @param {Object} options - Options for Droppable
    */
   constructor(containers = [], options = {}) {
-    super(containers, options);
-
-    this.options = {...defaults, ...this.options};
+    super(containers, {
+      ...defaultOptions,
+      ...options,
+      classes: {
+        ...defaultClasses,
+        ...(options.classes || {}),
+      },
+      announcements: {
+        ...defaultAnnouncements,
+        ...(options.announcements || {}),
+      },
+    });
 
     /**
      * All droppable elements on drag start
@@ -84,15 +127,6 @@ export default class Droppable extends Draggable {
       .off('drag:start', this[onDragStart])
       .off('drag:move', this[onDragMove])
       .off('drag:stop', this[onDragStop]);
-  }
-
-  /**
-   * Returns class name for class identifier
-   * @param {String} name - Name of class identifier
-   * @return {String|null}
-   */
-  getClassNameFor(name) {
-    return super.getClassNameFor(name) || classes[name];
   }
 
   /**

--- a/src/Sortable/Sortable.js
+++ b/src/Sortable/Sortable.js
@@ -13,6 +13,38 @@ const onDragOver = Symbol('onDragOver');
 const onDragStop = Symbol('onDragStop');
 
 /**
+ * Returns announcement message when a Draggable element has been sorted with another Draggable element
+ * or moved into a new container
+ * @param {SortableSortedEvent} sortableEvent
+ * @return {String}
+ */
+function onSortableSortedDefaultAnnouncement({dragEvent}) {
+  const sourceText = dragEvent.source.textContent.trim() || dragEvent.source.id || 'sortable element';
+
+  if (dragEvent.over) {
+    const overText = dragEvent.over.textContent.trim() || dragEvent.over.id || 'sortable element';
+    const isFollowing = dragEvent.source.compareDocumentPosition(dragEvent.over) & Node.DOCUMENT_POSITION_FOLLOWING;
+
+    if (isFollowing) {
+      return `Placed ${sourceText} after ${overText}`;
+    } else {
+      return `Placed ${sourceText} before ${overText}`;
+    }
+  } else {
+    // need to figure out how to compute container name
+    return `Placed ${sourceText} into a different container`;
+  }
+}
+
+/**
+ * @const {Object} defaultAnnouncements
+ * @const {Function} defaultAnnouncements['sortable:sorted']
+ */
+const defaultAnnouncements = {
+  'sortable:sorted': onSortableSortedDefaultAnnouncement,
+};
+
+/**
  * Sortable is built on top of Draggable and allows sorting of draggable elements. Sortable will keep
  * track of the original index and emits the new index as you drag over draggable elements.
  * @class Sortable
@@ -28,7 +60,13 @@ export default class Sortable extends Draggable {
    * @param {Object} options - Options for Sortable
    */
   constructor(containers = [], options = {}) {
-    super(containers, options);
+    super(containers, {
+      ...options,
+      announcements: {
+        ...defaultAnnouncements,
+        ...(options.announcements || {}),
+      },
+    });
 
     /**
      * start index of source on drag start

--- a/src/Swappable/Swappable.js
+++ b/src/Swappable/Swappable.js
@@ -12,6 +12,26 @@ const onDragOver = Symbol('onDragOver');
 const onDragStop = Symbol('onDragStop');
 
 /**
+ * Returns an announcement message when the Draggable element is swapped with another draggable element
+ * @param {SwappableSwappedEvent} swappableEvent
+ * @return {String}
+ */
+function onSwappableSwappedDefaultAnnouncement({dragEvent, swappedElement}) {
+  const sourceText = dragEvent.source.textContent.trim() || dragEvent.source.id || 'swappable element';
+  const overText = swappedElement.textContent.trim() || swappedElement.id || 'swappable element';
+
+  return `Swapped ${sourceText} with ${overText}`;
+}
+
+/**
+ * @const {Object} defaultAnnouncements
+ * @const {Function} defaultAnnouncements['swappabled:swapped']
+ */
+const defaultAnnouncements = {
+  'swappabled:swapped': onSwappableSwappedDefaultAnnouncement,
+};
+
+/**
  * Swappable is built on top of Draggable and allows swapping of draggable elements.
  * Order is irrelevant to Swappable.
  * @class Swappable
@@ -27,7 +47,13 @@ export default class Swappable extends Draggable {
    * @param {Object} options - Options for Swappable
    */
   constructor(containers = [], options = {}) {
-    super(containers, options);
+    super(containers, {
+      ...options,
+      announcements: {
+        ...defaultAnnouncements,
+        ...(options.announcements || {}),
+      },
+    });
 
     /**
      * Last draggable element that was dragged over


### PR DESCRIPTION
### This PR implements

Adds the `Announcement` plugin, which let's users define announcements via options on a per-event basis.

### Does this PR require the Docs to be updated?

Yes, provided some docs for the announcement plugin.