### PR TITLE
test(dragging): ensure dragging flag is set to false on drag:start cancel

### DIFF
--- a/src/Draggable/tests/Draggable.test.js
+++ b/src/Draggable/tests/Draggable.test.js
@@ -414,6 +414,28 @@ describe('Draggable', () => {
       .toBeInstanceOf(DragStartEvent);
   });
 
+  test('sets dragging to false when `drag:start` event is canceled', () => {
+    const newInstance = new Draggable(containers, {
+      draggable: 'li',
+    });
+    const draggableElement = sandbox.querySelector('li');
+    document.elementFromPoint = () => draggableElement;
+
+    const callback = jest.fn((event) => {
+      event.cancel();
+    });
+    newInstance.on('drag:start', callback);
+
+    triggerEvent(draggableElement, 'mousedown', {button: 0});
+
+    // Wait for delay
+    jest.runTimersToTime(100);
+
+    triggerEvent(draggableElement, 'dragstart', {button: 0});
+
+    expect(newInstance.dragging).toBeFalsy();
+  });
+
   test('triggers `drag:move` drag event on mousedown', () => {
     const newInstance = new Draggable(containers, {
       draggable: 'li',


### PR DESCRIPTION
Excellent library - thank you for all your hard work.

This PR fixes issues with the mirror not having a parent node when you cancel drag start.

Root cause:
- this.mirror gets removed when you cancel the drag:start event
- drag:stop event also tries to remove this.mirror, which is no longer attached to the DOM.

Related to:
https://github.com/Shopify/draggable/issues/106
https://github.com/Shopify/draggable/issues/85