### PR TITLE
Mirror improvements

### DIFF
--- a/src/Draggable/Plugins/Mirror/Mirror.js
+++ b/src/Draggable/Plugins/Mirror/Mirror.js
@@ -9,12 +9,16 @@ export const onMirrorMove = Symbol('onMirrorMove');
  * @property {Boolean} defaultOptions.constrainDimensions
  * @property {Boolean} defaultOptions.xAxis
  * @property {Boolean} defaultOptions.yAxis
+ * @property {null} defaultOptions.cursorOffsetX
+ * @property {null} defaultOptions.cursorOffsetY
  * @type {Object}
  */
 export const defaultOptions = {
   constrainDimensions: false,
   xAxis: true,
   yAxis: true,
+  cursorOffsetX: null,
+  cursorOffsetY: null,
 };
 
 /**
@@ -39,6 +43,8 @@ export default class Mirror extends AbstractPlugin {
      * @property {Boolean} options.constrainDimensions
      * @property {Boolean} options.xAxis
      * @property {Boolean} options.yAxis
+     * @property {Number|null} options.cursorOffsetX
+     * @property {Number|null} options.cursorOffsetY
      * @type {Object}
      */
     this.options = {
@@ -156,14 +162,14 @@ function computeMirrorDimensions({source, ...args}) {
  * @return {Promise}
  * @private
  */
-function calculateMirrorOffset({sensorEvent, sourceRect, ...args}) {
+function calculateMirrorOffset({sensorEvent, sourceRect, options, ...args}) {
   return withPromise((resolve) => {
-    const mirrorOffset = {
-      top: sensorEvent.clientY - sourceRect.top,
-      left: sensorEvent.clientX - sourceRect.left,
-    };
+    const top = options.cursorOffsetY === null ? (sensorEvent.clientY - sourceRect.top) : options.cursorOffsetY;
+    const left = options.cursorOffsetX === null ? (sensorEvent.clientX - sourceRect.left) : options.cursorOffsetX;
 
-    resolve({sensorEvent, sourceRect, mirrorOffset, ...args});
+    const mirrorOffset = {top, left};
+
+    resolve({sensorEvent, sourceRect, mirrorOffset, options, ...args});
   });
 }
 

--- a/src/Draggable/Plugins/Mirror/Mirror.js
+++ b/src/Draggable/Plugins/Mirror/Mirror.js
@@ -182,9 +182,9 @@ function resetMirror({mirror, source, options, ...args}) {
     let offsetWidth;
 
     if (options.constrainDimensions) {
-      // Compute padding for source
-      offsetHeight = source.clientHeight;
-      offsetWidth = source.clientWidth;
+      const computedSourceStyles = getComputedStyle(source);
+      offsetHeight = computedSourceStyles.getPropertyValue('height');
+      offsetWidth = computedSourceStyles.getPropertyValue('width');
     }
 
     mirror.style.position = 'fixed';
@@ -194,9 +194,8 @@ function resetMirror({mirror, source, options, ...args}) {
     mirror.style.margin = 0;
 
     if (options.constrainDimensions) {
-      // remove padding from dimensions
-      mirror.style.height = `${offsetHeight}px`;
-      mirror.style.width = `${offsetWidth}px`;
+      mirror.style.height = offsetHeight;
+      mirror.style.width = offsetWidth;
     }
 
     resolve({mirror, source, options, ...args});

--- a/src/Draggable/Plugins/Mirror/README.md
+++ b/src/Draggable/Plugins/Mirror/README.md
@@ -19,6 +19,12 @@ If enabled, the mirror will move on the y axis. Default: `true`
 **`constrainDimensions {Boolean}`**  
 If enabled, the source elements height and width will be applied to the mirror. Default: `false`
 
+**`cursorOffsetX {Number|null}`**  
+Defining this sets the offset from cursor to mirror manually on the x axis. Default: `null`
+
+**`cursorOffsetY {Number|null}`**  
+Defining this sets the offset from cursor to mirror manually on the y axis. Default: `null`
+
 ### Examples
 
 #### y Axis only
@@ -29,6 +35,9 @@ import {Draggable} from '@shopify/draggable';
 const draggable = new Draggable(document.querySelectorAll('ul'), {
   draggable: 'li',
   mirror: {
+    constrainDimensions: true,
+    cursorOffsetX: 10,
+    cursorOffsetY: 10,
     xAxis: false,
   },
 });
@@ -42,6 +51,9 @@ import {Sortable} from '@shopify/draggable';
 const sortable = new Sortable(document.querySelectorAll('ul'), {
   draggable: 'li',
   mirror: {
+    constrainDimensions: true,
+    cursorOffsetX: 10,
+    cursorOffsetY: 10,
     yAxis: false,
   },
 });


### PR DESCRIPTION
### This PR implements and fixes...

**Mirror Plugin**
- Computes correct mirror dimension when `constrainDimensions` is enabled
- Allow positioning of mirror relative to cursor via options `cursorOffsetX` & `cursorOffsetY`

### Does this PR require the Docs to be updated?

Yup

### This branch been tested on...

**Browsers:**

* [x] Chrome _version_
* [x] Firefox _version_
* [x] Safari _version_
* [x] IE / Edge _version_
* [x] iOS Browser _version_
* [x] Android Browser _version_
