### PR TITLE
Fixes mirror position and auto scroll on touch

### DIFF
--- a/src/Draggable/Plugins/AutoScroll/AutoScroll.js
+++ b/src/Draggable/Plugins/AutoScroll/AutoScroll.js
@@ -138,8 +138,8 @@ export default class AutoScroll extends AbstractPlugin {
     const sensorEvent = dragEvent.sensorEvent;
 
     this.currentMousePosition = {
-      clientX: sensorEvent.clientX,
-      clientY: sensorEvent.clientY,
+      clientX: sensorEvent.clientX - window.scrollX,
+      clientY: sensorEvent.clientY - window.scrollY,
     };
 
     this.scrollAnimationFrame = requestAnimationFrame(this[scroll]);

--- a/src/Draggable/Plugins/Mirror/Mirror.js
+++ b/src/Draggable/Plugins/Mirror/Mirror.js
@@ -257,8 +257,8 @@ function positionMirror({withFrame = false, initial = false} = {}) {
       };
 
       if (mirrorOffset) {
-        const x = sensorEvent.clientX - mirrorOffset.left;
-        const y = sensorEvent.clientY - mirrorOffset.top;
+        const x = sensorEvent.clientX - mirrorOffset.left - window.scrollX;
+        const y = sensorEvent.clientY - mirrorOffset.top - window.scrollY;
 
         if ((options.xAxis && options.yAxis) || initial) {
           mirror.style.transform = `translate3d(${x}px, ${y}px, 0)`;


### PR DESCRIPTION
### This PR fixes...

**Mirror Plugin**
- Fixes mirror positioning on scroll while dragging on touch devices. Mirror positioning is now offset with `window.scrollX` and `window.scrollY`

**AutoScroll Plugin**
- Auto scrolls correctly on touch while dragging on touch devices. Mouse position is now offset with `window.scrollX` and `window.scrollY`

### This branch been tested on...
**Browsers:**

* [x] Chrome _version_
* [x] Firefox _version_
* [x] Safari _version_
* [x] IE / Edge _version_
* [x] iOS Browser _version_
* [x] Android Browser _version_
