### PR TITLE
Rename AutoScroll to Scrollable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@
 ### Added
 
 - Default `Draggable` plugins get exposed statically on `Draggable.Plugins`
-- Default `AutoScroll` plugin for Draggable, which auto scrolls containers/viewport while dragging
+- Default `Scrollable` plugin for Draggable, which auto scrolls containers/viewport while dragging
 - `yarn watch` task for auto-building the library
 - `source:original` class option for Draggable
 - `Draggable#getDraggableElementsForContainer` method, which returns all draggable elements for a given container

--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ You can find the documentation for each module within their respective directori
   - [Plugins](src/Draggable/Plugins)
     - [Accessibility](src/Draggable/Plugins/Accessibility)
     - [Mirror](src/Draggable/Plugins/Mirror)
-    - [AutoScroll](src/Draggable/Plugins/AutoScroll)
+    - [Scrollable](src/Draggable/Plugins/Scrollable)
   - [Sensors](src/Draggable/Sensors)
     - [DragSensor](src/Draggable/Sensors/DragSensor)
     - [ForceTouchSensor](src/Draggable/Sensors/ForceTouchSensor)

--- a/src/Draggable/Draggable.js
+++ b/src/Draggable/Draggable.js
@@ -1,6 +1,6 @@
 import {closest} from 'shared/utils';
 
-import {Accessibility, Mirror, AutoScroll, Announcement} from './Plugins';
+import {Accessibility, Mirror, Scrollable, Announcement} from './Plugins';
 
 import {
   MouseSensor,
@@ -81,11 +81,11 @@ export default class Draggable {
    * @property {Object} Plugins
    * @property {Mirror} Plugins.Mirror
    * @property {Accessibility} Plugins.Accessibility
-   * @property {AutoScroll} Plugins.AutoScroll
+   * @property {Scrollable} Plugins.Scrollable
    * @property {Announcement} Plugins.Announcement
    * @type {Object}
    */
-  static Plugins = {Mirror, Accessibility, AutoScroll, Announcement};
+  static Plugins = {Mirror, Accessibility, Scrollable, Announcement};
 
   /**
    * Draggable constructor.
@@ -154,7 +154,7 @@ export default class Draggable {
     document.addEventListener('drag:stop', this[onDragStop], true);
     document.addEventListener('drag:pressure', this[onDragPressure], true);
 
-    this.addPlugin(...[Mirror, Accessibility, AutoScroll, Announcement, ...this.options.plugins]);
+    this.addPlugin(...[Mirror, Accessibility, Scrollable, Announcement, ...this.options.plugins]);
     this.addSensor(...[MouseSensor, TouchSensor, ...this.options.sensors]);
 
     const draggableInitializedEvent = new DraggableInitializedEvent({

--- a/src/Draggable/Plugins/AutoScroll/index.js
+++ b/src/Draggable/Plugins/AutoScroll/index.js
@@ -1,4 +1,0 @@
-import AutoScroll, {defaultOptions} from './AutoScroll';
-
-export default AutoScroll;
-export {defaultOptions};

--- a/src/Draggable/Plugins/README.md
+++ b/src/Draggable/Plugins/README.md
@@ -4,5 +4,5 @@ These plugins are included by draggable by default
 
 - [Accessibility](Accessibility)
 - [Mirror](Mirror)
-- [AutoScroll](AutoScroll)
+- [Scrollable](Scrollable)
 - [Announcement](Announcement)

--- a/src/Draggable/Plugins/Scrollable/README.md
+++ b/src/Draggable/Plugins/Scrollable/README.md
@@ -1,4 +1,4 @@
-## AutoScroll
+## Scrollable
 
 The auto scroll plugin listens to Draggables `drag:start`, `drag:move` and `drag:stop` events to determine when to scroll
 the document it's on.
@@ -6,18 +6,18 @@ This plugin is used by draggable by default, but could potentially be replaced w
 
 ### API
 
-**`new AutoScroll(draggable: Draggable): AutoScroll`**  
+**`new Scrollable(draggable: Draggable): Scrollable`**
 To create an auto scroll plugin instance.
 
 ### Options
 
-**`speed {Number}`**  
+**`speed {Number}`**
 Determines the scroll speed. Default: `10`
 
-**`sensitivity {Number}`**  
+**`sensitivity {Number}`**
 Determines the sensitivity of scrolling. Default: `30`
 
-**`scrollableElements {HTMLElement[]}`**  
+**`scrollableElements {HTMLElement[]}`**
 Allows users to specify their own scrollable elements, rather than letting Draggable compute these automatically. Default: `[]`
 
 ### Examples
@@ -29,7 +29,7 @@ const customScrollableElements = document.querySelectorAll('.my-custom-scroll-el
 
 const draggable = new Draggable(document.querySelectorAll('ul'), {
   draggable: 'li',
-  autoScroll: {
+  scrollable: {
     speed: 6,
     sensitivity: 12,
     scrollableElements: [
@@ -48,8 +48,8 @@ const draggable = new Draggable(document.querySelectorAll('ul'), {
   draggable: 'li',
 });
 
-// Removes AutoScroll plugin
-draggable.removePlugin(Draggable.Plugin.AutoScroll);
+// Removes Scrollable plugin
+draggable.removePlugin(Draggable.Plugin.Scrollable);
 
 // Adds custom scroll plugin
 draggable.addPlugin(CustomScrollPlugin);

--- a/src/Draggable/Plugins/Scrollable/Scrollable.js
+++ b/src/Draggable/Plugins/Scrollable/Scrollable.js
@@ -7,7 +7,7 @@ export const onDragStop = Symbol('onDragStop');
 export const scroll = Symbol('scroll');
 
 /**
- * AutoScroll default options
+ * Scrollable default options
  * @property {Object} defaultOptions
  * @property {Number} defaultOptions.speed
  * @property {Number} defaultOptions.sensitivity
@@ -21,23 +21,23 @@ export const defaultOptions = {
 };
 
 /**
- * AutoScroll plugin which scrolls the closest scrollable parent
- * @class AutoScroll
- * @module AutoScroll
+ * Scrollable plugin which scrolls the closest scrollable parent
+ * @class Scrollable
+ * @module Scrollable
  * @extends AbstractPlugin
  */
-export default class AutoScroll extends AbstractPlugin {
+export default class Scrollable extends AbstractPlugin {
 
   /**
-   * AutoScroll constructor.
-   * @constructs AutoScroll
+   * Scrollable constructor.
+   * @constructs Scrollable
    * @param {Draggable} draggable - Draggable instance
    */
   constructor(draggable) {
     super(draggable);
 
     /**
-     * AutoScroll options
+     * Scrollable options
      * @property {Object} options
      * @property {Number} options.speed
      * @property {Number} options.sensitivity
@@ -110,7 +110,7 @@ export default class AutoScroll extends AbstractPlugin {
    * @return {Object}
    */
   getOptions() {
-    return this.draggable.options.autoScroll || {};
+    return this.draggable.options.scrollable || {};
   }
 
   /**

--- a/src/Draggable/Plugins/Scrollable/index.js
+++ b/src/Draggable/Plugins/Scrollable/index.js
@@ -1,0 +1,4 @@
+import Scrollable, {defaultOptions} from './Scrollable';
+
+export default Scrollable;
+export {defaultOptions};

--- a/src/Draggable/Plugins/index.js
+++ b/src/Draggable/Plugins/index.js
@@ -9,9 +9,9 @@ export {
 } from './Announcement';
 
 export {
-  default as AutoScroll,
-  defaultOptions as defaultAutoScrollOptions,
-} from './AutoScroll';
+  default as Scrollable,
+  defaultOptions as defaultScrollableOptions,
+} from './Scrollable';
 
 export {
   default as Accessibility,

--- a/src/Draggable/tests/Draggable.test.js
+++ b/src/Draggable/tests/Draggable.test.js
@@ -22,7 +22,7 @@ import {
 import {
   Accessibility,
   Mirror,
-  AutoScroll,
+  Scrollable,
   Announcement,
 } from './../Plugins';
 
@@ -59,7 +59,7 @@ describe('Draggable', () => {
       expect(Draggable.Plugins).toBeDefined();
       expect(Draggable.Plugins.Mirror).toEqual(Mirror);
       expect(Draggable.Plugins.Accessibility).toEqual(Accessibility);
-      expect(Draggable.Plugins.AutoScroll).toEqual(AutoScroll);
+      expect(Draggable.Plugins.Scrollable).toEqual(Scrollable);
     });
   });
 
@@ -121,7 +121,7 @@ describe('Draggable', () => {
         .toBeInstanceOf(Accessibility);
 
       expect(newInstance.plugins[2])
-        .toBeInstanceOf(AutoScroll);
+        .toBeInstanceOf(Scrollable);
 
       expect(newInstance.plugins[3])
         .toBeInstanceOf(Announcement);


### PR DESCRIPTION
### This PR implements or fixes... _(explain your changes)_
Renaming the `AutoScroll` plugin to `Scrollable`... missed this when it was first added. At least we are catching it before the full stable release.

### This PR closes the following issues... _(if applicable)_
https://github.com/Shopify/draggable/issues/141

### Does this PR require the Docs to be updated?
Already done 👍 

### Does this PR require new tests?
Nope

### This branch been tested on... _(click all that apply / add new items)_

**Browsers:**

* [ ] Chrome _version_
* [ ] Firefox _version_
* [ ] Safari _version_
* [ ] IE / Edge _version_
* [ ] iOS Browser _version_
* [ ] Android Browser _version_
