### PR TITLE
Adds snappable element to SnapEvent

### DIFF
--- a/src/Plugins/Snappable/Snappable.js
+++ b/src/Plugins/Snappable/Snappable.js
@@ -107,6 +107,7 @@ export default class Snappable extends AbstractPlugin {
 
     const snapInEvent = new SnapInEvent({
       dragEvent: event,
+      snappable: event.over || event.droppable,
     });
 
     this.draggable.trigger(snapInEvent);
@@ -143,6 +144,7 @@ export default class Snappable extends AbstractPlugin {
 
     const snapOutEvent = new SnapOutEvent({
       dragEvent: event,
+      snappable: event.over || event.droppable,
     });
 
     this.draggable.trigger(snapOutEvent);

--- a/src/Plugins/Snappable/SnappableEvent/README.md
+++ b/src/Plugins/Snappable/SnappableEvent/README.md
@@ -14,6 +14,9 @@ The base snap event for all Snap events that `Snappable` emits.
 **`snapEvent.dragEvent: DragEvent`**  
 Read-only property for drag event that triggered this snappable event
 
+**`snapEvent.snappable: HTMLElement`**  
+Read-only property for the element that you are about to snap into or out of
+
 ## SnapInEvent
 
 `SnapInEvent` gets triggered by `Snappable` before snapping into place.

--- a/src/Plugins/Snappable/SnappableEvent/SnappableEvent.js
+++ b/src/Plugins/Snappable/SnappableEvent/SnappableEvent.js
@@ -18,6 +18,16 @@ export class SnapEvent extends AbstractEvent {
   get dragEvent() {
     return this.data.dragEvent;
   }
+
+  /**
+   * Snappable element
+   * @property snappable
+   * @type {HTMLElement}
+   * @readonly
+   */
+  get snappable() {
+    return this.data.snappable;
+  }
 }
 
 /**


### PR DESCRIPTION
### This PR implements or fixes...

Adds `snappable` property to `SnapEvent`, to find out the element you are about to snap into or our of

### Does this PR require the Docs to be updated?

Yes
