### PR TITLE
DroppableEvent changes

### DIFF
--- a/examples/src/components/Block/variants.scss
+++ b/examples/src/components/Block/variants.scss
@@ -149,7 +149,7 @@
 .BlockWrapper {
   position: relative;
 
-  &.draggable-droppable--occupied {
+  &.draggable-dropzone--occupied {
     .Block--typeHollow,
     .Block--typeStripes {
       @include position-cover;

--- a/examples/src/content/Droppable/UniqueDropzone/UniqueDropzone.html
+++ b/examples/src/content/Droppable/UniqueDropzone/UniqueDropzone.html
@@ -3,35 +3,35 @@
 {% macro render(id) %}
   <section id="{{ id }}" class="{{ id }}">
     <article class="BlockLayout BlockLayout--typeFlex">
-      <div class="BlockWrapper BlockWrapper--isDroppable draggable-droppable--occupied" data-droppable="1">
+      <div class="BlockWrapper BlockWrapper--isDropzone draggable-dropzone--occupied" data-dropzone="1">
         {{ Block.render('one', {type: 'Hollow'}) }}
         {{ Block.render('one', {index: 1, draggable: true}) }}
       </div>
-      <div class="BlockWrapper BlockWrapper--isDroppable draggable-droppable--occupied" data-droppable="2">
+      <div class="BlockWrapper BlockWrapper--isDropzone draggable-dropzone--occupied" data-dropzone="2">
         {{ Block.render('two', {type: 'Hollow'}) }}
         {{ Block.render('two', {index: 2, draggable: true}) }}
       </div>
-      <div class="BlockWrapper BlockWrapper--isDroppable draggable-droppable--occupied" data-droppable="4">
+      <div class="BlockWrapper BlockWrapper--isDropzone draggable-dropzone--occupied" data-dropzone="4">
         {{ Block.render('four', {type: 'Hollow'}) }}
         {{ Block.render('four', {index: 4, draggable: true}) }}
       </div>
-      <div class="BlockWrapper BlockWrapper--isDroppable draggable-droppable--occupied" data-droppable="8">
+      <div class="BlockWrapper BlockWrapper--isDropzone draggable-dropzone--occupied" data-dropzone="8">
         {{ Block.render('eight', {type: 'Hollow'}) }}
         {{ Block.render('eight', {index: 8, draggable: true}) }}
       </div>
     </article>
 
     <article class="BlockLayout BlockLayout--typeGrid">
-      <div class="BlockWrapper BlockWrapper--isDroppable" data-droppable="1">
+      <div class="BlockWrapper BlockWrapper--isDropzone" data-dropzone="1">
         {{ Block.render('', {type: 'Stripes'}) }}
       </div>
-      <div class="BlockWrapper BlockWrapper--isDroppable" data-droppable="2">
+      <div class="BlockWrapper BlockWrapper--isDropzone" data-dropzone="2">
         {{ Block.render('', {type: 'Stripes'}) }}
       </div>
       <div class="BlockWrapper">
         {{ Block.render('three', {index: 3, type: 'Shell'}) }}
       </div>
-      <div class="BlockWrapper BlockWrapper--isDroppable" data-droppable="4">
+      <div class="BlockWrapper BlockWrapper--isDropzone" data-dropzone="4">
         {{ Block.render('', {type: 'Stripes'}) }}
       </div>
       <div class="BlockWrapper">
@@ -43,7 +43,7 @@
       <div class="BlockWrapper">
         {{ Block.render('seven', {index: 7, type: 'Shell'}) }}
       </div>
-      <div class="BlockWrapper BlockWrapper--isDroppable" data-droppable="8">
+      <div class="BlockWrapper BlockWrapper--isDropzone" data-dropzone="8">
         {{ Block.render('', {type: 'Stripes'}) }}
       </div>
     </article>

--- a/examples/src/content/Droppable/UniqueDropzone/UniqueDropzone.scss
+++ b/examples/src/content/Droppable/UniqueDropzone/UniqueDropzone.scss
@@ -57,7 +57,7 @@ $grid-columns: 4;
       border-width: get-border();
     }
 
-    .BlockWrapper--isDroppable {
+    .BlockWrapper--isDropzone {
       &::before {
         content: '';
         position: absolute;
@@ -80,7 +80,7 @@ $grid-columns: 4;
       }
 
       // not focusable, but, whatever... this was hard to solve
-      &.draggable-droppable--occupied:hover {
+      &.draggable-dropzone--occupied:hover {
         &::before {
           opacity: 1;
         }

--- a/examples/src/content/Droppable/UniqueDropzone/index.js
+++ b/examples/src/content/Droppable/UniqueDropzone/index.js
@@ -11,7 +11,7 @@ export default function UniqueDropzone() {
 
   const droppable = new Droppable(containers, {
     draggable: '.Block--isDraggable',
-    droppable: '.BlockWrapper--isDroppable',
+    dropzone: '.BlockWrapper--isDropzone',
     mirror: {
       constrainDimensions: true,
     },
@@ -21,11 +21,11 @@ export default function UniqueDropzone() {
 
   // --- Draggable events --- //
   droppable.on('drag:start', (evt) => {
-    droppableOrigin = evt.originalSource.parentNode.dataset.droppable;
+    droppableOrigin = evt.originalSource.parentNode.dataset.dropzone;
   });
 
-  droppable.on('droppable:over', (evt) => {
-    if (droppableOrigin !== evt.droppable.dataset.droppable) {
+  droppable.on('droppable:dropped', (evt) => {
+    if (droppableOrigin !== evt.dropzone.dataset.dropzone) {
       evt.cancel();
     }
   });

--- a/examples/src/content/Plugins/Collidable/Collidable.html
+++ b/examples/src/content/Plugins/Collidable/Collidable.html
@@ -3,7 +3,7 @@
 {% macro render(id) %}
   <section id="{{ id }}" class="{{ id }}">
     <article class="BlockLayout BlockLayout--typePositioned">
-      <div class="BlockWrapper BlockWrapper--isDroppable draggable-droppable--occupied">
+      <div class="BlockWrapper BlockWrapper--isDropzone draggable-dropzone--occupied">
         {{ Block.render('drop', {type: 'Hollow'}) }}
         {{ Block.render('drag', {index: 1, draggable: true}) }}
       </div>
@@ -11,7 +11,7 @@
       {{ Block.render('', {index: 2, type: 'Stripes', classes: ['CollidableObstacle']}) }}
       {{ Block.render('', {index: 3, type: 'Stripes', classes: ['CollidableObstacle']}) }}
 
-      <div class="BlockWrapper BlockWrapper--isDroppable">
+      <div class="BlockWrapper BlockWrapper--isDropzone">
         {{ Block.render('drop', {index: 4, type: 'Hollow'}) }}
       </div>
 

--- a/examples/src/content/Plugins/Collidable/index.js
+++ b/examples/src/content/Plugins/Collidable/index.js
@@ -14,7 +14,7 @@ export default function PluginsCollidable() {
 
   const droppable = new Droppable(containers, {
     draggable: '.Block--isDraggable',
-    droppable: '.BlockWrapper--isDroppable',
+    dropzone: '.BlockWrapper--isDropzone',
     collidables: '.CollidableObstacle',
     appendTo: containerSelector,
     mirror: {

--- a/scripts/test/matchers/event.js
+++ b/scripts/test/matchers/event.js
@@ -1,0 +1,65 @@
+import {expectation} from './utils';
+
+function toHaveBeenCalledWithEvent(jestFunction, expectedEventConstructor) {
+  const mockFunction = jestFunction.mock;
+  const mockCalls = mockFunction.calls;
+  let pass;
+  let message;
+
+  pass = !mockCalls.length;
+  if (pass) {
+    message = () => `Expected ${expectedEventConstructor.type} event ${expectation(pass)} triggered`;
+    return {pass, message};
+  }
+
+  const event = mockCalls[0][0];
+
+  pass = !event;
+  if (pass) {
+    message = () =>
+      `Expected ${expectedEventConstructor.type} event ${expectation(pass)} triggered with an event instance`;
+    return {pass, message};
+  }
+
+  pass = event.constructor === expectedEventConstructor;
+
+  return {
+    pass,
+    message: () =>
+      `Expected ${event.type} event ${expectation(pass)} triggered with ${expectedEventConstructor.name} instance`,
+  };
+}
+
+function toHaveBeenCalledWithEventProperties(jestFunction, expectedProperties) {
+  const mockFunction = jestFunction.mock;
+  const mockCalls = mockFunction.calls;
+  const event = mockCalls[0][0];
+  const expectedPropertyEntries = Object.entries(expectedProperties);
+
+  const badMatches = expectedPropertyEntries
+    .map(([key, value]) => ({key, value}))
+    .filter(({key, value}) => event[key] !== value);
+
+  const receivedPropertyEntries = Object.entries(event);
+
+  const pass = Boolean(!badMatches.length);
+
+  return {
+    pass,
+    message: () => {
+      const listOfExpectedProperties = expectedPropertyEntries.map(([key, value]) => `${key}=${value}`);
+      const listOfReceivedProperties = receivedPropertyEntries.map(([key, value]) => `${key}=${value}`);
+
+      return `Expected ${event.type} event ${expectation(
+        pass,
+      )} the following properties:\n${listOfExpectedProperties.join(
+        '\n',
+      )}\n\nInstead received:\n${listOfReceivedProperties.join('\n')}\n`;
+    },
+  };
+}
+
+expect.extend({
+  toHaveBeenCalledWithEvent,
+  toHaveBeenCalledWithEventProperties,
+});

--- a/scripts/test/matchers/index.js
+++ b/scripts/test/matchers/index.js
@@ -1,3 +1,4 @@
 import './dom-event';
+import './event';
 import './order';
 import './sensor';

--- a/scripts/test/matchers/utils.js
+++ b/scripts/test/matchers/utils.js
@@ -1,0 +1,3 @@
+export function expectation(passed) {
+  return passed ? 'not to have' : 'to have';
+}

--- a/src/Droppable/DroppableEvent/DroppableEvent.js
+++ b/src/Droppable/DroppableEvent/DroppableEvent.js
@@ -21,43 +21,85 @@ export class DroppableEvent extends AbstractEvent {
 }
 
 /**
- * Droppable over event
- * @class DroppableOverEvent
- * @module DroppableOverEvent
+ * Droppable start event
+ * @class DroppableStartEvent
+ * @module DroppableStartEvent
  * @extends DroppableEvent
  */
-export class DroppableOverEvent extends DroppableEvent {
-  static type = 'droppable:over';
+export class DroppableStartEvent extends DroppableEvent {
+  static type = 'droppable:start';
   static cancelable = true;
 
   /**
-   * The droppable element you are over
-   * @property droppable
+   * The initial dropzone element of the currently dragging draggable element
+   * @property dropzone
    * @type {HTMLElement}
    * @readonly
    */
-  get droppable() {
-    return this.data.droppable;
+  get dropzone() {
+    return this.data.dropzone;
   }
 }
 
 /**
- * Droppable out event
- * @class DroppableOutEvent
- * @module DroppableOutEvent
+ * Droppable dropped event
+ * @class DroppableDroppedEvent
+ * @module DroppableDroppedEvent
  * @extends DroppableEvent
  */
-export class DroppableOutEvent extends DroppableEvent {
-  static type = 'droppable:out';
+export class DroppableDroppedEvent extends DroppableEvent {
+  static type = 'droppable:dropped';
   static cancelable = true;
 
   /**
-   * The droppable element you _were_ over
-   * @property droppable
+   * The dropzone element you dropped the draggable element into
+   * @property dropzone
    * @type {HTMLElement}
    * @readonly
    */
-  get droppable() {
-    return this.data.droppable;
+  get dropzone() {
+    return this.data.dropzone;
+  }
+}
+
+/**
+ * Droppable returned event
+ * @class DroppableReturnedEvent
+ * @module DroppableReturnedEvent
+ * @extends DroppableEvent
+ */
+export class DroppableReturnedEvent extends DroppableEvent {
+  static type = 'droppable:returned';
+  static cancelable = true;
+
+  /**
+   * The dropzone element you dragged away from
+   * @property dropzone
+   * @type {HTMLElement}
+   * @readonly
+   */
+  get dropzone() {
+    return this.data.dropzone;
+  }
+}
+
+/**
+ * Droppable stop event
+ * @class DroppableStopEvent
+ * @module DroppableStopEvent
+ * @extends DroppableEvent
+ */
+export class DroppableStopEvent extends DroppableEvent {
+  static type = 'droppable:stop';
+  static cancelable = true;
+
+  /**
+   * The final dropzone element of the draggable element
+   * @property dropzone
+   * @type {HTMLElement}
+   * @readonly
+   */
+  get dropzone() {
+    return this.data.dropzone;
   }
 }

--- a/src/Droppable/DroppableEvent/README.md
+++ b/src/Droppable/DroppableEvent/README.md
@@ -2,48 +2,82 @@
 
 The base droppable event for all Droppable events that `Droppable` emits.
 
-| | |
-| --------------------- | ---------------------------------------------------------- |
-| **Interface**         | `DroppableEvent`                                           |
-| **Cancelable**        | false                                                      |
-| **Cancel action**     | -                                                          |
-| **type**              | `droppable`                                                |
+|                   |                  |
+| ----------------- | ---------------- |
+| **Interface**     | `DroppableEvent` |
+| **Cancelable**    | false            |
+| **Cancel action** | -                |
+| **type**          | `droppable`      |
 
 ### API
 
 **`droppableEvent.dragEvent: DragEvent`**  
 Read-only property for the original drag event that triggered the droppable event.
 
-## DroppableOverEvent
+## DroppableStartEvent
 
-`DroppableOverEvent` gets triggered by `Droppable` before dropping the draggable element into a droppable element.
+`DroppableStartEvent` gets triggered by `Droppable` before dropping the draggable element into a dropzone element.
 
-| | |
-| --------------------- | ---------------------------------------------------------- |
-| **Specification**     | `DroppableEvent`                                           |
-| **Interface**         | `DroppableOverEvent`                                       |
-| **Cancelable**        | true                                                       |
-| **Cancel action**     | Prevents drop                                              |
-| **type**              | `droppable:over`                                           |
-
-### API
-
-**`droppableEvent.droppable: HTMLElement`**  
-Read-only property for the droppable element you are over.
-
-## DroppableOutEvent
-
-`DroppableOutEvent` gets triggered by `Droppable` before moving the draggable element to its original position.
-
-| | |
-| --------------------- | ---------------------------------------------------------- |
-| **Specification**     | `DroppableEvent`                                           |
-| **Interface**         | `DroppableOutEvent`                                        |
-| **Cancelable**        | true                                                       |
-| **Cancel action**     | Prevents release                                           |
-| **type**              | `droppable:out`                                           |
+|                   |                       |
+| ----------------- | --------------------- |
+| **Specification** | `DroppableEvent`      |
+| **Interface**     | `DroppableStartEvent` |
+| **Cancelable**    | true                  |
+| **Cancel action** | Prevents drag         |
+| **type**          | `droppable:start`     |
 
 ### API
 
-**`droppableEvent.droppable: HTMLElement`**  
-Read-only property for the droppable element you were over.
+**`droppableEvent.dropzone: HTMLElement`**  
+Read-only property for the initial dropzone element of the currently dragging draggable element
+
+## DroppableDroppedEvent
+
+`DroppableDroppedEvent` gets triggered by `Droppable` before dropping the draggable element into a dropzone element.
+
+|                   |                         |
+| ----------------- | ----------------------- |
+| **Specification** | `DroppableEvent`        |
+| **Interface**     | `DroppableDroppedEvent` |
+| **Cancelable**    | true                    |
+| **Cancel action** | Prevents drop           |
+| **type**          | `droppable:dropped`     |
+
+### API
+
+**`droppableEvent.dropzone: HTMLElement`**  
+Read-only property for the dropzone element you dropped the draggable element into
+
+## DroppableReturnedEvent
+
+`DroppableReturnedEvent` gets triggered by `Droppable` before moving the draggable element to its original dropzone.
+
+|                   |                                      |
+| ----------------- | ------------------------------------ |
+| **Specification** | `DroppableEvent`                     |
+| **Interface**     | `DroppableReturnedEvent`             |
+| **Cancelable**    | true                                 |
+| **Cancel action** | Prevents return of draggable element |
+| **type**          | `droppable:returned`                 |
+
+### API
+
+**`droppableEvent.dropzone: HTMLElement`**  
+Read-only property for the dropzone element you dragged away from
+
+## DroppableStopEvent
+
+`DroppableStopEvent` gets triggered by `Droppable` before dropping the draggable element into a dropzone element.
+
+|                   |                      |
+| ----------------- | -------------------- |
+| **Specification** | `DroppableEvent`     |
+| **Interface**     | `DroppableStopEvent` |
+| **Cancelable**    | false                |
+| **Cancel action** | -                    |
+| **type**          | `droppable:start`    |
+
+### API
+
+**`droppableEvent.dropzone: HTMLElement`**  
+Read-only property for the final dropzone element of the draggable element

--- a/src/Droppable/README.md
+++ b/src/Droppable/README.md
@@ -1,12 +1,12 @@
 ## Droppable
 
 Droppable is built on top of Draggable and allows you to declare draggable and droppable elements via options.
-Droppable fires two events on top of the draggable events: `droppable:over` and `droppable:out`.
+Droppable fires two events on top of the draggable events: `droppable:dropped` and `droppable:returned`.
 
 ### Import
 
 ```js
-import {Droppable} from '@shopify/draggable';
+import { Droppable } from '@shopify/draggable';
 ```
 
 ```js
@@ -29,43 +29,43 @@ Check out [Draggables API](../Draggable#api) for the base API
 
 Check out [Draggables options](../Draggable#options) for the base options
 
-**`droppable {String|HTMLElement[]|NodeList|Function}`**  
-A css selector string, an array of elements, a NodeList or a function returning elements for droppable
-elements within the `containers` specified.
+**`dropzone {String|HTMLElement[]|NodeList|Function}`**  
+A css selector string, an array of elements, a NodeList or a function returning elements for dropzone
+elements within the `containers`.
 
 ### Events
 
 Check out [Draggables events](../Draggable#events) for base events
 
-| Name                               | Description                                                | Cancelable  | Cancelable action    |
-| ---------------------------------- | ---------------------------------------------------------- | ----------- | -------------------- |
-| [`droppable:over`][droppableover]  | Gets fired when dragging over droppable element            | true        | Prevents drop        |
-| [`droppable:out`][droppableout]    | Gets fired when dragging out of a droppable element        | true        | Prevents release     |
+| Name                                      | Description                                                     | Cancelable | Cancelable action |
+| ----------------------------------------- | --------------------------------------------------------------- | ---------- | ----------------- |
+| [`droppable:dropped`][droppabledropped]   | Gets fired when dropping draggable element into a dropzone      | true       | Prevents drop     |
+| [`droppable:returned`][droppablereturned] | Gets fired when draggable elements returns to original dropzone | true       | Prevents return   |
 
-[droppableover]: DroppableEvent#droppableoverevent
-[droppableout]: DroppableEvent#droppableoutevent
+[droppabledropped]: DroppableEvent#droppabledroppedevent
+[droppablereturned]: DroppableEvent#droppablereturnedevent
 
 ### Classes
 
 Check out [Draggables class identifiers](../Draggable#classes)
 
-| Name                 | Description                                                          | Default                            |
-| -------------------- | -------------------------------------------------------------------- | ---------------------------------- |
-| `droppable:active`   | Class added on droppables when drag starts                           | `draggable-droppable--active`      |
-| `droppable:occupied` | Class added on droppable element, when it contains a draggable       | `draggable-droppable--occupied`    |
+| Name                 | Description                                                    | Default                         |
+| -------------------- | -------------------------------------------------------------- | ------------------------------- |
+| `droppable:active`   | Class added on droppables when drag starts                     | `draggable-droppable--active`   |
+| `droppable:occupied` | Class added on droppable element, when it contains a draggable | `draggable-droppable--occupied` |
 
 ### Example
 
 This sample code will make list items draggable and allows to drop them inside another element:
 
 ```js
-import {Droppable} from '@shopify/draggable';
+import { Droppable } from '@shopify/draggable';
 
 const droppable = new Droppable(document.querySelectorAll('ul'), {
   draggable: 'li',
-  droppable: '#dropzone',
+  dropzone: '#dropzone'
 });
 
-droppable.on('droppable:over', () => console.log('droppable:over'));
-droppable.on('droppable:out', () => console.log('droppable:out'));
+droppable.on('droppable:dropped', () => console.log('droppable:dropped'));
+droppable.on('droppable:returned', () => console.log('droppable:returned'));
 ```

--- a/src/Droppable/tests/Droppable.test.js
+++ b/src/Droppable/tests/Droppable.test.js
@@ -1,0 +1,235 @@
+import {createSandbox, clickMouse, moveMouse, releaseMouse, waitForDragDelay, DRAG_DELAY} from 'helper';
+
+import Droppable, {DroppableStartEvent, DroppableDroppedEvent, DroppableReturnedEvent, DroppableStopEvent} from '..';
+
+const sampleMarkup = `
+  <div class="Container">
+    <div class="Dropzone isOccupied">
+      <div class="Draggable"></div>
+    </div>
+    <div class="Dropzone"></div>
+    <div class="Dropzone isOccupied">
+      <div class="Draggable"></div>
+    </div>
+    <div class="Draggable"></div>
+  </div>
+`;
+
+describe('Droppable', () => {
+  let sandbox;
+  let containers;
+  let draggableElement;
+  let dropzoneElements;
+  let droppable;
+  let firstDropzone;
+  let secondDropzone;
+  let occupiedDropzone;
+  let dropzonelessDraggableElement;
+
+  beforeEach(() => {
+    sandbox = createSandbox(sampleMarkup);
+    containers = sandbox.querySelectorAll('.Container');
+    draggableElement = sandbox.querySelector('.Draggable');
+    dropzoneElements = sandbox.querySelectorAll('.Dropzone');
+    dropzonelessDraggableElement = sandbox.querySelectorAll('.Draggable')[2];
+    firstDropzone = dropzoneElements[0];
+    secondDropzone = dropzoneElements[1];
+    occupiedDropzone = dropzoneElements[2];
+    droppable = new Droppable(containers, {
+      draggable: '.Draggable',
+      dropzone: '.Dropzone',
+      delay: DRAG_DELAY,
+      classes: {
+        'droppable:occupied': 'isOccupied',
+      },
+    });
+  });
+
+  afterEach(() => {
+    droppable.destroy();
+    sandbox.parentNode.removeChild(sandbox);
+  });
+
+  describe('triggers', () => {
+    let eventHandler;
+    let originalDragEvents;
+
+    beforeEach(() => {
+      eventHandler = jest.fn();
+      originalDragEvents = [];
+    });
+
+    it('droppable:start event', () => {
+      droppable.on('drag:start', (dragEvent) => originalDragEvents.push(dragEvent));
+      droppable.on('droppable:start', eventHandler);
+
+      move();
+
+      expect(eventHandler).toHaveBeenCalledWithEvent(DroppableStartEvent);
+
+      expect(eventHandler).toHaveBeenCalledWithEventProperties({
+        dragEvent: originalDragEvents[0],
+        dropzone: firstDropzone,
+      });
+    });
+
+    it('droppable:dropped event', () => {
+      droppable.on('drag:move', (dragEvent) => originalDragEvents.push(dragEvent));
+      droppable.on('droppable:dropped', eventHandler);
+
+      move();
+
+      expect(eventHandler).toHaveBeenCalledWithEvent(DroppableDroppedEvent);
+
+      expect(eventHandler).toHaveBeenCalledWithEventProperties({
+        dragEvent: originalDragEvents[0],
+        dropzone: secondDropzone,
+      });
+    });
+
+    it('droppable:returned event', () => {
+      droppable.on('drag:move', (dragEvent) => originalDragEvents.push(dragEvent));
+      droppable.on('droppable:returned', eventHandler);
+
+      move(() => {
+        moveMouse(firstDropzone);
+        moveMouse(secondDropzone);
+      });
+
+      expect(eventHandler).toHaveBeenCalledWithEvent(DroppableReturnedEvent);
+
+      expect(eventHandler).toHaveBeenCalledWithEventProperties({
+        dragEvent: originalDragEvents[1],
+        dropzone: secondDropzone,
+      });
+    });
+
+    it('droppable:stop event', () => {
+      droppable.on('drag:stop', (dragEvent) => originalDragEvents.push(dragEvent));
+      droppable.on('droppable:stop', eventHandler);
+
+      move();
+
+      expect(eventHandler).toHaveBeenCalledWithEvent(DroppableStopEvent);
+
+      expect(eventHandler).toHaveBeenCalledWithEventProperties({
+        dragEvent: originalDragEvents[0],
+        dropzone: secondDropzone,
+      });
+    });
+  });
+
+  it('prevents drag when canceling sortable start event', () => {
+    droppable.on('droppable:start', (droppableEvent) => {
+      droppableEvent.cancel();
+    });
+
+    clickMouse(draggableElement);
+    waitForDragDelay();
+    moveMouse(secondDropzone);
+
+    expect(droppable.isDragging()).toBe(false);
+
+    releaseMouse(droppable.source);
+  });
+
+  it('drops draggable element in an empty droppable element', () => {
+    expect(draggableElement.parentNode).toBe(firstDropzone);
+
+    clickMouse(draggableElement);
+    waitForDragDelay();
+    moveMouse(secondDropzone);
+
+    expect(droppable.source.parentNode).toBe(secondDropzone);
+
+    releaseMouse(droppable.source);
+  });
+
+  it('prevents drop on occupied droppable element', () => {
+    const handler = jest.fn();
+
+    droppable.on('droppable:dropped', handler);
+
+    expect(draggableElement.parentNode).toBe(firstDropzone);
+
+    clickMouse(draggableElement);
+    waitForDragDelay();
+    moveMouse(occupiedDropzone);
+
+    expect(droppable.source.parentNode).toBe(firstDropzone);
+
+    expect(handler).not.toHaveBeenCalled();
+
+    releaseMouse(droppable.source);
+  });
+
+  it('prevents drop when droppable:dropped event gets canceled', () => {
+    droppable.on('droppable:dropped', (droppableEvent) => {
+      droppableEvent.cancel();
+    });
+
+    clickMouse(draggableElement);
+    waitForDragDelay();
+    moveMouse(secondDropzone);
+
+    expect(droppable.source.parentNode).toBe(firstDropzone);
+
+    releaseMouse(droppable.source);
+  });
+
+  it('prevents release when droppable:returned event gets canceled', () => {
+    droppable.on('droppable:returned', (droppableEvent) => {
+      droppableEvent.cancel();
+    });
+
+    clickMouse(draggableElement);
+    waitForDragDelay();
+    moveMouse(secondDropzone);
+    moveMouse(firstDropzone);
+
+    expect(droppable.source.parentNode).toBe(secondDropzone);
+
+    releaseMouse(droppable.source);
+  });
+
+  describe('when dragging element without dropzone as parent', () => {
+    it('does not trigger droppable:start event', () => {
+      const droppableStartHandler = jest.fn();
+      droppable.on('droppable:start', droppableStartHandler);
+
+      clickMouse(dropzonelessDraggableElement);
+      waitForDragDelay();
+
+      expect(droppableStartHandler).not.toHaveBeenCalled();
+
+      releaseMouse(droppable.source);
+    });
+
+    it('cancels drag:start event', () => {
+      droppable.on('drag:start', (dragEvent) => {
+        requestAnimationFrame(() => {
+          // because user defined get triggered first we need to
+          // wait for droppable to cancel the event
+          expect(dragEvent.canceled()).toBe(true);
+        });
+      });
+
+      clickMouse(dropzonelessDraggableElement);
+      waitForDragDelay();
+
+      releaseMouse(droppable.source);
+    });
+  });
+
+  function move(
+    optionalMoves = () => {
+      /* noop */
+    },
+  ) {
+    clickMouse(draggableElement);
+    waitForDragDelay();
+    moveMouse(secondDropzone);
+    optionalMoves();
+    releaseMouse(droppable.source);
+  }
+});


### PR DESCRIPTION
### This PR implements or fixes...

- Adds cancelable `DroppableStartEvent`
- Adds `DroppableStopEvent`
- Renames `DroppableOverEvent` to `DroppableDroppedEvent`
- Renames `DroppableOutEvent` to `DroppableReturnedEvent`
- Renames `droppable` option to `dropzone`

### Does this PR require the Docs to be updated?

Yes
