### PR TITLE
fix(dragstart): cleanup DOM modifications when drag:start is canceled

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,6 @@ example.html
 coverage/
 docs/
 lib/
+
+# 'cause we are all yarny and stuff
+package-lock.json

--- a/src/Draggable/Draggable.js
+++ b/src/Draggable/Draggable.js
@@ -438,6 +438,9 @@ export default class Draggable {
         this.mirror.parentNode.removeChild(this.mirror);
       }
 
+      this.source.parentNode.removeChild(this.source);
+      this.originalSource.style.display = null;
+
       this.source.classList.remove(this.getClassNameFor('source:dragging'));
       this.sourceContainer.classList.remove(this.getClassNameFor('container:dragging'));
       document.body.classList.remove(this.getClassNameFor('body:dragging'));

--- a/src/Draggable/tests/Draggable.test.js
+++ b/src/Draggable/tests/Draggable.test.js
@@ -418,16 +418,21 @@ describe('Draggable', () => {
       .toBeInstanceOf(DragStartEvent);
   });
 
-  test('sets dragging to false when `drag:start` event is canceled', () => {
+  test('cleans up when `drag:start` event is canceled', () => {
     const newInstance = new Draggable(containers, {
       draggable: 'li',
     });
     const draggableElement = sandbox.querySelector('li');
     document.elementFromPoint = () => draggableElement;
 
+    let source;
+    let originalSource;
     const callback = jest.fn((event) => {
+      source = event.source;
+      originalSource = event.originalSource;
       event.cancel();
     });
+
     newInstance.on('drag:start', callback);
 
     triggerEvent(draggableElement, 'mousedown', {button: 0});
@@ -438,6 +443,8 @@ describe('Draggable', () => {
     triggerEvent(draggableElement, 'dragstart', {button: 0});
 
     expect(newInstance.dragging).toBeFalsy();
+    expect(source.parentNode).toBeNull();
+    expect(originalSource.style.display).toEqual('');
   });
 
   test('triggers `drag:move` drag event on mousedown', () => {


### PR DESCRIPTION
> Thank you for submitting a pull request! Please make sure you have read the [contribution guidelines](https://github.com/Shopify/draggable/blob/master/CONTRIBUTING.md) before proceeding.

### This PR fixes cleanup when the drag:start event is cancelled.

Specifically, the cloned source node is still in the DOM and the original element has its display style attribute set to none. 

This change reverts the DOM to its original, pre-drag:start, state.

### Does this PR require the Docs to be updated?

No
…

### Does this PR require new tests?

Yes, and they are added.

### This branch been tested on... _(click all that apply / add new items)_

**Browsers:**

* [x] Chrome 63.0.3239.132 (Official Build) (64-bit)
* [x] Firefox 58.0.2 (64-bit)
* [x] Safari 11.0.3 (12604.5.6.1.1)
* [ ] IE / Edge _version_
* [ ] iOS Browser _version_
* [ ] Android Browser _version_
