### PR TITLE
fix(package): cannot cd into examples if the folder is not created

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,8 @@
     "test-ci": "jest --config config.json --coverage"
   },
   "files": [
-    "lib/**/*.js"
+    "lib/**/*.js",
+    "examples/"
   ],
   "devDependencies": {
     "babel-core": "^6.26.0",


### PR DESCRIPTION
> Thank you for submitting a pull request! Please make sure you have read the [contribution guidelines](https://github.com/Shopify/draggable/blob/master/CONTRIBUTING.md) before proceeding.

### This PR fixes the package.json files field.
The examples directory is not included in the package files specification so a clean install will fail when the post installation task tries to `cd examples && yarn`

```
sh: line 0: cd: examples: No such file or directory
npm ERR! code ELIFECYCLE
npm ERR! errno 1
npm ERR! @shopify/draggable@1.0.0-beta.4 postinstall: `cd examples && yarn`
npm ERR! Exit status 1
npm ERR!
npm ERR! Failed at the @shopify/draggable@1.0.0-beta.4 postinstall script.
npm ERR! This is probably not a problem with npm. There is likely additional logging output above.
```
…

__Consideration_ could also be given to not yarning out the examples on every install. For now, I'm just trying to get rid of the install failures._

### This PR closes no issues

…

### Does this PR require the Docs to be updated?
No

…

### Does this PR require new tests?
No
…

### This branch been tested on

**Node/Npm**

* [x] Node v9.2.0
* [x] npm 0.29.0

**Browsers:**
N/A