### PR TITLE
Fixes overContainer reference in drag:out:container event

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,21 @@
+{
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "type": "node",
+      "request": "launch",
+      "name": "Jest Tests",
+      "program": "${workspaceRoot}/node_modules/jest/bin/jest.js",
+      "args": [
+          "--config",
+          "config.json",
+          "-i",
+          "--watchAll"
+      ],
+      "internalConsoleOptions": "openOnSessionStart",
+      "outFiles": [
+          "${workspaceRoot}/dist/**/*"
+      ],
+    }
+  ]
+}

--- a/src/Draggable/Draggable.js
+++ b/src/Draggable/Draggable.js
@@ -520,7 +520,7 @@ export default class Draggable {
         originalSource: this.originalSource,
         sourceContainer: container,
         sensorEvent,
-        overContainer: this.overContainer,
+        overContainer: this.currentOverContainer,
       });
 
       this.currentOverContainer.classList.remove(this.getClassNameFor('container:over'));

--- a/src/Draggable/tests/Draggable.test.js
+++ b/src/Draggable/tests/Draggable.test.js
@@ -759,4 +759,40 @@ describe('Draggable', () => {
 
     expect(draggableElement.classList.contains(newInstance.getClassNameFor('source:original'))).toBeFalsy();
   });
+
+  test('`drag:out:container` event specifies leaving container', () => {
+    const newInstance = new Draggable(containers, {
+      draggable: 'li',
+    });
+
+    newInstance.on('drag:over:container', (dragEvent) => {
+      expect(dragEvent.overContainer).toEqual(containers[0]);
+    });
+
+    newInstance.on('drag:out:container', (dragEvent) => {
+      expect(dragEvent.overContainer).toEqual(containers[0]);
+    });
+
+    const draggableElement = sandbox.querySelector('li');
+    document.elementFromPoint = () => draggableElement;
+
+    triggerEvent(draggableElement, 'mousedown', {button: 0});
+
+    // Wait for delay
+    jest.runTimersToTime(100);
+
+    expect(newInstance.isDragging()).toBe(true);
+
+    document.elementFromPoint = () => draggableElement.nextElementSibling;
+    triggerEvent(draggableElement.nextElementSibling, 'mousemove', {button: 0});
+
+    // Wait for delay
+    jest.runTimersToTime(100);
+
+    document.elementFromPoint = () => document.body;
+    triggerEvent(document.body, 'mousemove', {button: 0});
+
+    // Wait for delay
+    jest.runTimersToTime(100);
+  });
 });


### PR DESCRIPTION
### This PR fixes

Fixes the `overContainer` reference in `DragOutContainerEvent`.

### This PR closes the following issues... _(if applicable)_

- https://github.com/Shopify/draggable/issues/155

### Does this PR require the Docs to be updated?

Nope

### Does this PR require new tests?

Yes
