### PR TITLE
Introduces Emitter for draggable

### DIFF
--- a/src/Draggable/Draggable.js
+++ b/src/Draggable/Draggable.js
@@ -2,6 +2,8 @@ import {closest} from 'shared/utils';
 
 import {Accessibility, Mirror, Scrollable, Announcement} from './Plugins';
 
+import Emitter from './Emitter';
+
 import {
   MouseSensor,
   TouchSensor,
@@ -121,7 +123,12 @@ export default class Draggable {
       },
     };
 
-    this.callbacks = {};
+    /**
+     * Draggables event emitter
+     * @property emitter
+     * @type {Emitter}
+     */
+    this.emitter = new Emitter();
 
     /**
      * Current drag state
@@ -263,16 +270,12 @@ export default class Draggable {
   /**
    * Adds listener for draggable events
    * @param {String} type - Event name
-   * @param {Function} callback - Event callback
+   * @param {...Function} callbacks - Event callbacks
    * @return {Draggable}
    * @example draggable.on('drag:start', (dragEvent) => dragEvent.cancel());
    */
-  on(type, callback) {
-    if (!this.callbacks[type]) {
-      this.callbacks[type] = [];
-    }
-
-    this.callbacks[type].push(callback);
+  on(type, ...callbacks) {
+    this.emitter.on(type, ...callbacks);
     return this;
   }
 
@@ -284,13 +287,7 @@ export default class Draggable {
    * @example draggable.off('drag:start', handlerFunction);
    */
   off(type, callback) {
-    if (!this.callbacks[type]) { return null; }
-    const copy = this.callbacks[type].slice(0);
-    for (let i = 0; i < copy.length; i++) {
-      if (callback === copy[i]) {
-        this.callbacks[type].splice(i, 1);
-      }
-    }
+    this.emitter.off(type, callback);
     return this;
   }
 
@@ -301,12 +298,7 @@ export default class Draggable {
    * @example draggable.trigger(event);
    */
   trigger(event) {
-    if (!this.callbacks[event.type]) { return null; }
-    const callbacks = [...this.callbacks[event.type]];
-    for (let i = callbacks.length - 1; i >= 0; i--) {
-      const callback = callbacks[i];
-      callback(event);
-    }
+    this.emitter.trigger(event);
     return this;
   }
 

--- a/src/Draggable/Emitter/Emitter.js
+++ b/src/Draggable/Emitter/Emitter.js
@@ -1,0 +1,74 @@
+/**
+ * The Emitter is a simple emitter class that provides you with `on()`, `off()` and `trigger()` methods
+ * @class Emitter
+ * @module Emitter
+ */
+export default class Emitter {
+  constructor() {
+    this.callbacks = {};
+  }
+
+  /**
+   * Registers callbacks by event name
+   * @param {String} type
+   * @param {...Function} callbacks
+   */
+  on(type, ...callbacks) {
+    if (!this.callbacks[type]) {
+      this.callbacks[type] = [];
+    }
+
+    this.callbacks[type].push(...callbacks);
+
+    return this;
+  }
+
+  /**
+   * Unregisters callbacks by event name
+   * @param {String} type
+   * @param {Function} callback
+   */
+  off(type, callback) {
+    if (!this.callbacks[type]) {
+      return null;
+    }
+
+    const copy = this.callbacks[type].slice(0);
+
+    for (let i = 0; i < copy.length; i++) {
+      if (callback === copy[i]) {
+        this.callbacks[type].splice(i, 1);
+      }
+    }
+
+    return this;
+  }
+
+  /**
+   * Triggers event callbacks by event object
+   * @param {AbstractEvent} event
+   */
+  trigger(event) {
+    if (!this.callbacks[event.type]) {
+      return null;
+    }
+
+    const callbacks = [...this.callbacks[event.type]];
+    const caughtErrors = [];
+
+    for (let i = callbacks.length - 1; i >= 0; i--) {
+      const callback = callbacks[i];
+      try {
+        callback(event);
+      } catch (error) {
+        caughtErrors.push(error);
+      }
+    }
+
+    if (caughtErrors.length) {
+      throw new Error(`Draggable caught errors while triggering '${event.type}'`, caughtErrors);
+    }
+
+    return this;
+  }
+}

--- a/src/Draggable/Emitter/index.js
+++ b/src/Draggable/Emitter/index.js
@@ -1,0 +1,3 @@
+import Emitter from './Emitter';
+
+export default Emitter;

--- a/src/Draggable/Emitter/tests/Emitter.test.js
+++ b/src/Draggable/Emitter/tests/Emitter.test.js
@@ -1,0 +1,76 @@
+import AbstractEvent from 'shared/AbstractEvent';
+import Emitter from './../Emitter';
+
+class TestEvent extends AbstractEvent {}
+
+describe('Emitter', () => {
+  let emitter;
+
+  beforeEach(() => {
+    emitter = new Emitter();
+  });
+
+  describe('#on', () => {
+    test('registers a callback by event type', () => {
+      const callback = jest.fn();
+
+      emitter.on('event', callback);
+
+      expect(emitter.callbacks.event).toContain(callback);
+    });
+
+    test('registers multiple callbacks by event type', () => {
+      const callbacks = [jest.fn(), jest.fn()];
+
+      emitter.on('event', ...callbacks);
+
+      expect(emitter.callbacks.event[0]).toEqual(callbacks[0]);
+      expect(emitter.callbacks.event[1]).toEqual(callbacks[1]);
+    });
+  });
+
+  describe('#off', () => {
+    test('removes a callback by event type', () => {
+      const callback = jest.fn();
+
+      emitter.on('event', callback);
+
+      expect(emitter.callbacks.event).toContain(callback);
+
+      emitter.off('event', callback);
+
+      expect(emitter.callbacks.event).not.toContain(callback);
+    });
+  });
+
+  describe('#trigger', () => {
+    test('triggers callbacks on event with test event', () => {
+      const testEvent = new TestEvent({});
+      const callback = jest.fn();
+
+      emitter.on('event', callback);
+      emitter.trigger(testEvent);
+
+      expect(callback).toHaveBeenCalled();
+      expect(callback).toHaveBeenCalledWith(testEvent);
+    });
+
+    test('catches errors from listeners and re-throws at the end of the trigger phase', () => {
+      const testEvent = new TestEvent({});
+      const callbacks = [
+        jest.fn(),
+        () => { throw new Error('Error'); },
+        jest.fn(),
+      ];
+
+      emitter.on('event', ...callbacks);
+
+      expect(() => {
+        emitter.trigger(testEvent);
+      }).toThrow(Error);
+
+      expect(callbacks[0]).toHaveBeenCalled();
+      expect(callbacks[2]).toHaveBeenCalled();
+    });
+  });
+});

--- a/src/Draggable/tests/Draggable.test.js
+++ b/src/Draggable/tests/Draggable.test.js
@@ -253,15 +253,15 @@ describe('Draggable', () => {
       const newInstance = new Draggable();
       function stubHandler() { /* do nothing */ }
 
-      expect('my:event' in newInstance.callbacks)
+      expect('my:event' in newInstance.emitter.callbacks)
         .toBe(false);
 
       newInstance.on('my:event', stubHandler);
 
-      expect('my:event' in newInstance.callbacks)
+      expect('my:event' in newInstance.emitter.callbacks)
         .toBe(true);
 
-      expect(newInstance.callbacks['my:event'])
+      expect(newInstance.emitter.callbacks['my:event'])
         .toMatchObject([stubHandler]);
     });
 
@@ -269,7 +269,7 @@ describe('Draggable', () => {
       const newInstance = new Draggable();
       function stubHandler() { /* do nothing */ }
 
-      expect('my:event' in newInstance.callbacks)
+      expect('my:event' in newInstance.emitter.callbacks)
         .toBe(false);
 
       const returnValue = newInstance.on('my:event', stubHandler);
@@ -280,33 +280,21 @@ describe('Draggable', () => {
   });
 
   describe('#off', () => {
-    test('should return null if event was not bound', () => {
-      const newInstance = new Draggable();
-      function stubHandler() { /* do nothing */ }
-
-      expect('my:event' in newInstance.callbacks)
-        .toBe(false);
-
-      const returnValue = newInstance.off('my:event', stubHandler);
-
-      expect(returnValue).toBe(null);
-    });
-
     test('should remove event handler from the list of callbacks', () => {
       const newInstance = new Draggable();
       function stubHandler() { /* do nothing */ }
 
       newInstance.on('my:event', stubHandler);
 
-      expect('my:event' in newInstance.callbacks)
+      expect('my:event' in newInstance.emitter.callbacks)
         .toBe(true);
 
       newInstance.off('my:event', stubHandler);
 
-      expect('my:event' in newInstance.callbacks)
+      expect('my:event' in newInstance.emitter.callbacks)
         .toBe(true);
 
-      expect(newInstance.callbacks['my:event'])
+      expect(newInstance.emitter.callbacks['my:event'])
         .toMatchObject([]);
     });
 
@@ -316,7 +304,7 @@ describe('Draggable', () => {
 
       newInstance.on('my:event', stubHandler);
 
-      expect('my:event' in newInstance.callbacks)
+      expect('my:event' in newInstance.emitter.callbacks)
         .toBe(true);
 
       const returnValue = newInstance.off('my:event', stubHandler);


### PR DESCRIPTION
### This PR implements

A dedicated event Emitter class for Draggable.

### This PR closes the following issues... _(if applicable)_

- https://github.com/Shopify/draggable/issues/160

### Does this PR require the Docs to be updated?

Nope

### Does this PR require new tests?

Yes