### PR TITLE
Fixes add/remove container api

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ### Changed
 
+- Fixed `addContainer`/`removeContainer` api
+
 ## v1.0.0-beta.5 - 2018-03-02
 
 ### Added

--- a/src/Draggable/Draggable.js
+++ b/src/Draggable/Draggable.js
@@ -249,10 +249,11 @@ export default class Draggable {
    * Adds container to this draggable instance
    * @param {...HTMLElement} containers - Containers you want to add to draggable
    * @return {Draggable}
-   * @example draggable.addPlugin(CustomA11yPlugin, CustomMirrorPlugin)
+   * @example draggable.addContainer(document.body)
    */
   addContainer(...containers) {
     this.containers = [...this.containers, ...containers];
+    this.sensors.forEach((sensor) => sensor.addContainer(...containers));
     return this;
   }
 
@@ -260,10 +261,11 @@ export default class Draggable {
    * Removes container from this draggable instance
    * @param {...HTMLElement} containers - Containers you want to remove from draggable
    * @return {Draggable}
-   * @example draggable.removePlugin(MirrorPlugin, CustomMirrorPlugin)
+   * @example draggable.removeContainer(document.body)
    */
   removeContainer(...containers) {
     this.containers = this.containers.filter((container) => !containers.includes(container));
+    this.sensors.forEach((sensor) => sensor.removeContainer(...containers));
     return this;
   }
 

--- a/src/Draggable/Sensors/Sensor/Sensor.js
+++ b/src/Draggable/Sensors/Sensor/Sensor.js
@@ -18,7 +18,7 @@ export default class Sensor {
      * @property containers
      * @type {HTMLElement[]}
      */
-    this.containers = containers;
+    this.containers = [...containers];
 
     /**
      * Current options
@@ -56,6 +56,24 @@ export default class Sensor {
    */
   detach() {
     return this;
+  }
+
+  /**
+   * Adds container to this sensor instance
+   * @param {...HTMLElement} containers - Containers you want to add to this sensor
+   * @example draggable.addContainer(document.body)
+   */
+  addContainer(...containers) {
+    this.containers = [...this.containers, ...containers];
+  }
+
+  /**
+   * Removes container from this sensor instance
+   * @param {...HTMLElement} containers - Containers you want to remove from this sensor
+   * @example draggable.removeContainer(document.body)
+   */
+  removeContainer(...containers) {
+    this.containers = this.containers.filter((container) => !containers.includes(container));
   }
 
   /**

--- a/src/Draggable/Sensors/Sensor/tests/Sensor.test.js
+++ b/src/Draggable/Sensors/Sensor/tests/Sensor.test.js
@@ -39,6 +39,36 @@ describe('Sensor', () => {
     });
   });
 
+  describe('#addContainer', () => {
+    test('adds container to sensor', () => {
+      const containers = [document.documentElement, document.body];
+      const sensor = new Sensor();
+
+      expect(sensor.containers)
+        .toEqual([]);
+
+      sensor.addContainer(...containers);
+
+      expect(sensor.containers)
+        .toEqual(containers);
+    });
+  });
+
+  describe('#removeContainer', () => {
+    test('removes container to sensor', () => {
+      const containers = [document.documentElement, document.body];
+      const sensor = new Sensor(containers);
+
+      expect(sensor.containers)
+        .toEqual(containers);
+
+      sensor.removeContainer(...containers);
+
+      expect(sensor.containers)
+        .toEqual([]);
+    });
+  });
+
   describe('#trigger', () => {
     test('should dispatch event on element', () => {
       const sensor = new Sensor();

--- a/src/Draggable/tests/Draggable.test.js
+++ b/src/Draggable/tests/Draggable.test.js
@@ -2,6 +2,10 @@ import {
   createSandbox,
   triggerEvent,
   TestPlugin,
+  clickMouse,
+  moveMouse,
+  releaseMouse,
+  waitForDragDelay,
 } from 'helper';
 
 import Draggable, {
@@ -32,7 +36,11 @@ import {
 } from './../Sensors';
 
 const sampleMarkup = `
-  <ul>
+  <ul class="Container">
+    <li>First item</li>
+    <li>Second item</li>
+  </ul>
+  <ul class="DynamicContainer">
     <li>First item</li>
     <li>Second item</li>
   </ul>
@@ -46,7 +54,7 @@ describe('Draggable', () => {
 
   beforeEach(() => {
     sandbox = createSandbox(sampleMarkup);
-    containers = sandbox.querySelectorAll('ul');
+    containers = sandbox.querySelectorAll('.Container');
   });
 
   afterEach(() => {
@@ -351,6 +359,86 @@ describe('Draggable', () => {
       expect(containerChildren.length).toEqual(2);
 
       triggerEvent(draggableElement, 'mouseup', {button: 0});
+    });
+  });
+
+  describe('#addContainer', () => {
+    test('adds single container dynamically', () => {
+      const dragOverContainerHandler = jest.fn();
+      const newInstance = new Draggable(containers, {
+        draggable: 'li',
+      });
+
+      newInstance.on('drag:over:container', dragOverContainerHandler);
+
+      const draggableElement = document.querySelector('li');
+      const dynamicContainer = document.querySelector('.DynamicContainer');
+
+      clickMouse(draggableElement);
+      waitForDragDelay(100);
+      moveMouse(dynamicContainer);
+
+      expect(dragOverContainerHandler)
+        .not
+        .toHaveBeenCalled();
+
+      releaseMouse(newInstance.source);
+
+      newInstance.addContainer(dynamicContainer);
+
+      expect(newInstance.containers)
+        .toEqual([...containers, dynamicContainer]);
+
+      clickMouse(draggableElement);
+      waitForDragDelay(100);
+      moveMouse(dynamicContainer);
+
+      expect(dragOverContainerHandler)
+        .toHaveBeenCalled();
+
+      releaseMouse(newInstance.source);
+    });
+  });
+
+  describe('#removeContainer', () => {
+    test('removes single container dynamically', () => {
+      let dragOverContainerHandler = jest.fn();
+      const allContainers = document.querySelectorAll('.Container, .DynamicContainer');
+      const newInstance = new Draggable(allContainers, {
+        draggable: 'li',
+      });
+
+      newInstance.on('drag:over:container', dragOverContainerHandler);
+
+      const draggableElement = document.querySelector('li');
+      const dynamicContainer = document.querySelector('.DynamicContainer');
+
+      clickMouse(draggableElement);
+      waitForDragDelay(100);
+      moveMouse(dynamicContainer);
+
+      expect(dragOverContainerHandler)
+        .toHaveBeenCalled();
+
+      releaseMouse(newInstance.source);
+
+      newInstance.removeContainer(dynamicContainer);
+
+      expect(newInstance.containers)
+        .toEqual([...containers]);
+
+      dragOverContainerHandler = jest.fn();
+      newInstance.on('drag:over:container', dragOverContainerHandler);
+
+      clickMouse(draggableElement);
+      waitForDragDelay(100);
+      moveMouse(dynamicContainer);
+
+      expect(dragOverContainerHandler)
+        .not
+        .toHaveBeenCalled();
+
+      releaseMouse(newInstance.source);
     });
   });
 


### PR DESCRIPTION
### This PR fixes...

Fixes Draggables `addContainer` & `removeContainer` api. Sensors used to rely on sharing the same reference of `containers` with draggable, but draggable changes its reference with a new array of container elements, when adding or removing them. This leaves sensors with a stale reference to `containers`.

### This PR closes the following issues...

https://github.com/Shopify/draggable/issues/166

### Does this PR require the Docs to be updated?

No

### Does this PR require new tests?

Yes

### This branch been tested on...

**Browsers:**

* [x] Chrome _version_
* [x] Firefox _version_
* [x] Safari _version_
* [x] IE / Edge _version_
* [x] iOS Browser _version_
* [x] Android Browser _version_

cc @dsandstrom @albertodarblade