### PR TITLE
Use console.error instead of throwing error

### DIFF
--- a/src/Draggable/Emitter/Emitter.js
+++ b/src/Draggable/Emitter/Emitter.js
@@ -67,7 +67,9 @@ export default class Emitter {
     }
 
     if (caughtErrors.length) {
-      throw new Error(`Draggable caught errors while triggering '${event.type}'`, caughtErrors);
+      /* eslint-disable no-console */
+      console.error(`Draggable caught errors while triggering '${event.type}'`, caughtErrors);
+      /* dislint-disable no-console */
     }
 
     return this;

--- a/src/Draggable/Emitter/tests/Emitter.test.js
+++ b/src/Draggable/Emitter/tests/Emitter.test.js
@@ -56,20 +56,28 @@ describe('Emitter', () => {
     });
 
     it('catches errors from listeners and re-throws at the end of the trigger phase', () => {
+      const consoleErrorSpy = jest.fn();
+
       const testEvent = new TestEvent({});
+      const error = new Error('Error');
       const callbacks = [
         jest.fn(),
         () => {
-          throw new Error('Error');
+          throw error;
         },
         jest.fn(),
       ];
 
+      /* eslint-disable no-console */
+      console.error = consoleErrorSpy;
+      /* eslint-enable no-console */
+
       emitter.on('event', ...callbacks);
 
-      expect(() => {
-        emitter.trigger(testEvent);
-      }).toThrow(Error);
+      emitter.trigger(testEvent);
+
+      expect(consoleErrorSpy).toHaveBeenCalled();
+      expect(consoleErrorSpy).toHaveBeenCalledWith("Draggable caught errors while triggering 'event'", [error]);
 
       expect(callbacks[0]).toHaveBeenCalled();
       expect(callbacks[2]).toHaveBeenCalled();


### PR DESCRIPTION
### This PR implements or fixes...

I noticed this feature was getting more annoying than it helps... Instead of throwing an error, it will `console.error` instead. Main reason for this is that `new Error()` only accepts an error message

### This branch been tested on...

**Browsers:**

* [x] Chrome _version_
* [x] Firefox _version_
* [x] Safari _version_
* [x] IE / Edge _version_
* [x] iOS Browser _version_
* [x] Android Browser _version_
