### PR TITLE
Touch sensor scrolling bug

### DIFF
--- a/examples/src/components/StackedList/variants.scss
+++ b/examples/src/components/StackedList/variants.scss
@@ -45,32 +45,6 @@
       opacity: 0.1;
     }
   }
-
-  // Size variants
-
-  .StackedListWrapper--sizeMedium & {
-    @include stacked-list-scroll-height(
-      stacked-list-item(medium), 3
-    );
-
-    @media screen and (min-width: get-breakpoint(desktop)) {
-      @include stacked-list-scroll-height(
-        stacked-list-item(medium, desktop), 3
-      );
-    }
-  }
-
-  .StackedListWrapper--sizeLarge & {
-    @include stacked-list-scroll-height(
-      stacked-list-item(large), 3
-    );
-
-    @media screen and (min-width: get-breakpoint(desktop)) {
-      @include stacked-list-scroll-height(
-        stacked-list-item(large, desktop), 3
-      );
-    }
-  }
 }
 
 .StackedList--hasScroll {

--- a/examples/src/content/Sortable/SimpleList/SimpleList.html
+++ b/examples/src/content/Sortable/SimpleList/SimpleList.html
@@ -2,18 +2,24 @@
 
 {% macro render(id) %}
   <section id="{{ id }}" class="{{ id }}">
-    <article class="StackedListWrapper">
+    <article class="StackedListWrapper StackedListWrapper--hasScrollIndicator">
       <header class="StackedListHeader">
         <h3 class="Heading Heading--size3 Heading--colorWhite">Simple list</h3>
       </header>
 
-      <ul class="StackedList">
-        {{ StackedListItem.render('item one',   {index: 1, draggable: true}) }}
-        {{ StackedListItem.render('item two',   {index: 2, draggable: true}) }}
-        {{ StackedListItem.render('item three', {index: 3, draggable: true}) }}
-        {{ StackedListItem.render('item four',  {index: 4, draggable: true}) }}
-        {{ StackedListItem.render('item five',  {index: 5}) }}
-        {{ StackedListItem.render('item six',   {index: 6, draggable: true}) }}
+      <ul class="StackedList StackedList--hasScroll">
+        {{ StackedListItem.render('item one',    {index: 1, draggable: true}) }}
+        {{ StackedListItem.render('item two',    {index: 2, draggable: true}) }}
+        {{ StackedListItem.render('item three',  {index: 3, draggable: true}) }}
+        {{ StackedListItem.render('item four',   {index: 4, draggable: true}) }}
+        {{ StackedListItem.render('item five',   {index: 5}) }}
+        {{ StackedListItem.render('item six',    {index: 6, draggable: true}) }}
+        {{ StackedListItem.render('item seven',  {index: 7, draggable: true}) }}
+        {{ StackedListItem.render('item eight',  {index: 8}) }}
+        {{ StackedListItem.render('item nine',   {index: 9}) }}
+        {{ StackedListItem.render('item ten',    {index: 10, draggable: true}) }}
+        {{ StackedListItem.render('item eleven', {index: 11}) }}
+        {{ StackedListItem.render('item twelve', {index: 12, draggable: true}) }}
       </ul>
     </article>
   </section>

--- a/examples/src/content/Sortable/SimpleList/SimpleList.scss
+++ b/examples/src/content/Sortable/SimpleList/SimpleList.scss
@@ -8,20 +8,4 @@
 
 .SimpleList {
   @include centered-width(columns(5));
-
-  .StackedListWrapper {
-    .StackedListHeader {
-      @media screen and (min-width: get-breakpoint(desktop)) {
-        display: flex;
-        align-items: center;
-        height: stacked-list-item(medium);
-      }
-    }
-
-    .StackedListContent {
-      @media screen and (min-width: get-breakpoint(desktop)) {
-        height: stacked-list-item(medium);
-      }
-    }
-  }
 }

--- a/src/Draggable/Sensors/TouchSensor/tests/TouchSensor.test.js
+++ b/src/Draggable/Sensors/TouchSensor/tests/TouchSensor.test.js
@@ -94,7 +94,7 @@ describe('TouchSensor', () => {
     expect(dragFlow).toHaveTriggeredSensorEvent('drag:stop');
   });
 
-  it('prevents `drag:start` when holding finger on none draggable element', () => {
+  it('prevents `drag:start` when trying to drag a none draggable element', () => {
     function dragFlow() {
       touchStart(document.body);
       waitForDragDelay();


### PR DESCRIPTION
### This PR fixes...

This fixes an issue with the `TouchSensor`, where the browser can get into both scrolling and dragging state, which causes all sorts of weirdness and there is no way to recover from.

After digging a little into the `Touch Events` spec, it looks like we can find out if the browser decides to scroll (even before `touchmove`) based on `TouchStartEvent#cancelable`.

> Canceling a touch event can prevent or otherwise interrupt scrolling (which could be happening in parallel with script execution). For maximum scroll performance, a user agent may not wait for each touch event associated with the scroll to be processed to see if it will be canceled. In such cases the user agent should generate touch events whose cancelable property is false, indicating that preventDefault cannot be used to prevent or interrupt scrolling. Otherwise cancelable will be true.

**Source**: https://w3c.github.io/touch-events/#cancelability

### This PR closes the following issues...

https://github.com/Shopify/draggable/issues/170

### Does this PR require the Docs to be updated?

Nope

### Does this PR require new tests?

Yup

### This branch been tested on...

**Browsers:**

* [x] Chrome _version_
* [ ] Firefox _version_
* [ ] Safari _version_
* [ ] IE / Edge _version_
* [x] iOS Browser _version_
* [x] Android Browser _version_
