### PR TITLE
Fixes legacy bundle

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -4,9 +4,11 @@ import AbstractPlugin from 'shared/AbstractPlugin';
 import * as Sensors from './Draggable/Sensors';
 import * as Plugins from './Plugins';
 
+export {AbstractEvent as BaseEvent, AbstractPlugin as BasePlugin};
+
 export {default as Draggable} from './Draggable';
 export {default as Droppable} from './Droppable';
 export {default as Swappable} from './Swappable';
 export {default as Sortable} from './Sortable';
 
-export {AbstractEvent as BaseEvent, AbstractPlugin as BasePlugin, Sensors, Plugins};
+export {Sensors, Plugins};

--- a/src/index.legacy.js
+++ b/src/index.legacy.js
@@ -1,6 +1,7 @@
 import 'core-js/es6/symbol';
 import 'core-js/es6/promise';
 import 'core-js/fn/object/assign';
+import 'core-js/fn/object/values';
 import 'core-js/fn/array/includes';
 
 import AbstractEvent from 'shared/AbstractEvent';
@@ -9,9 +10,18 @@ import AbstractPlugin from 'shared/AbstractPlugin';
 import * as Sensors from './Draggable/Sensors';
 import * as Plugins from './Plugins';
 
-export {default as Draggable} from './Draggable';
-export {default as Droppable} from './Droppable';
-export {default as Swappable} from './Swappable';
-export {default as Sortable} from './Sortable';
+import Draggable from './Draggable';
+import Droppable from './Droppable';
+import Swappable from './Swappable';
+import Sortable from './Sortable';
 
-export {AbstractEvent as BaseEvent, AbstractPlugin as BasePlugin, Sensors, Plugins};
+export {
+  AbstractEvent as BaseEvent,
+  AbstractPlugin as BasePlugin,
+  Draggable,
+  Droppable,
+  Swappable,
+  Sortable,
+  Sensors,
+  Plugins,
+};

--- a/src/tests/bundle.test.js
+++ b/src/tests/bundle.test.js
@@ -1,0 +1,11 @@
+import * as RealBundle from '../index';
+import * as LegacyBundle from '../index.legacy';
+
+describe('Package', () => {
+  it('exports the same bundles for legacy bundle', () => {
+    const realExports = Object.keys(RealBundle);
+    const legacyExports = Object.keys(LegacyBundle);
+
+    expect(legacyExports).toEqual(realExports);
+  });
+});


### PR DESCRIPTION
### This PR fixes...

This fixes imports of `core-js` for the legacy bundle. Apparently we need to import them first, so `core-js` can apply polyfills.

I added a test to make sure both `index.js` and `index.legacy.js` stay in sync

### This PR closes the following issues...

https://github.com/Shopify/draggable/issues/175

### Does this PR require the Docs to be updated?

No

### Does this PR require new tests?

Yes

### This branch been tested on...

**Browsers:**

* [ ] Chrome _version_
* [ ] Firefox _version_
* [ ] Safari _version_
* [x] IE / Edge _version_
* [ ] iOS Browser _version_
* [ ] Android Browser _version_
