### PR TITLE
Touch Sensor fix for scrolling

### DIFF
--- a/src/Draggable/Sensors/TouchSensor/tests/TouchSensor.test.js
+++ b/src/Draggable/Sensors/TouchSensor/tests/TouchSensor.test.js
@@ -103,25 +103,6 @@ describe('TouchSensor', () => {
     expect(dragFlow).not.toHaveTriggeredSensorEvent('drag:start');
   });
 
-  it('prevents `drag:start` when browser starts scrolling instead', () => {
-    function dragFlow() {
-      touchStart(draggableElement);
-      triggerEvent(document.body, 'scroll');
-      waitForDragDelay();
-    }
-
-    expect(dragFlow).not.toHaveTriggeredSensorEvent('drag:start');
-  });
-
-  it('prevents `drag:start` when touchstart event is not cancelable', () => {
-    function dragFlow() {
-      touchStart(draggableElement, {cancelable: false});
-      waitForDragDelay();
-    }
-
-    expect(dragFlow).not.toHaveTriggeredSensorEvent('drag:start');
-  });
-
   it('prevents `drag:start` when touch moved before drag delay', () => {
     function dragFlow() {
       touchStart(draggableElement);
@@ -153,15 +134,11 @@ describe('TouchSensor', () => {
 
     expect(touchMoveEvent.defaultPrevented).toBe(false);
 
-    expect(touchMoveEvent.stoppedPropagation).toBeUndefined();
-
     touchStart(draggableElement);
     waitForDragDelay();
     touchMoveEvent = touchMove(draggableElement);
 
     expect(touchMoveEvent.defaultPrevented).toBe(true);
-
-    expect(touchMoveEvent.stoppedPropagation).toBe(true);
 
     touchRelease(draggableElement);
   });


### PR DESCRIPTION
### This PR fixes...

With the release of iOS 11.3, passive events cannot be added dynamically anymore. Instead we need to add the `touchmove` listener as early as possible.

### This PR closes the following issues...

- https://github.com/Shopify/draggable/issues/198
- https://github.com/Shopify/draggable/issues/170

### Does this PR require the Docs to be updated?

Nope

### Does this PR require new tests?

Just update existing tests

### This branch been tested on...

**Browsers:**

* [x] Chrome _version_
* [ ] Firefox _version_
* [ ] Safari _version_
* [ ] IE / Edge _version_
* [x] iOS Browser _version_
* [x] Android Browser _version_
