### PR TITLE
Does not prevent drag start outside of draggable container

### DIFF
--- a/src/Draggable/Sensors/MouseSensor/MouseSensor.js
+++ b/src/Draggable/Sensors/MouseSensor/MouseSensor.js
@@ -75,7 +75,6 @@ export default class MouseSensor extends Sensor {
     }
 
     document.addEventListener('mouseup', this[onMouseUp]);
-    document.addEventListener('dragstart', preventNativeDragStart);
 
     const target = document.elementFromPoint(event.clientX, event.clientY);
     const container = closest(target, this.containers);
@@ -83,6 +82,9 @@ export default class MouseSensor extends Sensor {
     if (!container) {
       return;
     }
+
+    // Find closest natively draggable in future
+    document.addEventListener('dragstart', preventNativeDragStart);
 
     this.mouseDown = true;
 

--- a/src/Draggable/Sensors/MouseSensor/tests/MouseSensor.test.js
+++ b/src/Draggable/Sensors/MouseSensor/tests/MouseSensor.test.js
@@ -154,4 +154,14 @@ describe('MouseSensor', () => {
 
     releaseMouse(document.body);
   });
+
+  it('does not prevent `dragstart` event when attempting to drag outside of draggable container ', () => {
+    clickMouse(document.body);
+    waitForDragDelay();
+    const nativeDragEvent = triggerEvent(draggableElement, 'dragstart');
+
+    expect(nativeDragEvent).not.toHaveDefaultPrevented();
+
+    releaseMouse(document.body);
+  });
 });


### PR DESCRIPTION
### This PR fixes...

This PR fixes an issue with preventing native drag events outside of draggable containers. This change will prevent nativ drag events for draggable containers only

### This PR closes the following issues...

- https://github.com/Shopify/draggable/issues/210

### Does this PR require the Docs to be updated?

No

### Does this PR require new tests?

Yes

cc @jarben