### PR TITLE
Fixes missing mouse position bug for scrollable

### DIFF
--- a/src/Draggable/Plugins/Scrollable/Scrollable.js
+++ b/src/Draggable/Plugins/Scrollable/Scrollable.js
@@ -194,7 +194,7 @@ export default class Scrollable extends AbstractPlugin {
    * @private
    */
   [scroll]() {
-    if (!this.scrollableElement) {
+    if (!this.scrollableElement || !this.currentMousePosition) {
       return;
     }
 


### PR DESCRIPTION
### This PR fixes...

This fixes an issue where the `currentMousePosition`, in `Scrollable`, is reset on `drag:stop`, but still used in a later animation frame. This will guard for this case to bail early if `currentMousePosition` has been reset.

### This PR closes the following issues...

https://github.com/Shopify/draggable/issues/209

### Does this PR require the Docs to be updated?

No

### Does this PR require new tests?

No (No tests for `Scrollable` yet)

cc @smileytechguy 
