### PR TITLE
Fix initial drag move event cancelation

### DIFF
--- a/src/Draggable/Draggable.js
+++ b/src/Draggable/Draggable.js
@@ -451,14 +451,12 @@ export default class Draggable {
       document.body.classList.remove(this.getClassNameFor('body:dragging'));
     } else {
       requestAnimationFrame(() => {
-        // Temporary hack until we can correctly re-write the originalSource -> source
+        const oldSensorEvent = getSensorEvent(event);
+        const newSensorEvent = oldSensorEvent.clone({target: this.source});
+
         this[onDragMove]({
           ...event,
-          target: this.source,
-          detail: {
-            ...event.detail,
-            target: this.source,
-          },
+          detail: newSensorEvent,
         });
       });
     }

--- a/src/shared/AbstractEvent/AbstractEvent.js
+++ b/src/shared/AbstractEvent/AbstractEvent.js
@@ -71,4 +71,17 @@ export default class AbstractEvent {
   canceled() {
     return Boolean(this[canceled]);
   }
+
+  /**
+   * Returns new event instance with existing event data.
+   * This method allows for overriding of event data.
+   * @param {Object} data
+   * @return {AbstractEvent}
+   */
+  clone(data) {
+    return new this.constructor({
+      ...this.data,
+      ...data,
+    });
+  }
 }


### PR DESCRIPTION
### This PR implements or fixes...

Fixes issue when canceling first `drag:move`. The cancel function for `SensorEvent` does not work because we are destructing the sensor event to use the newly created source element as opposed to the original source, which has been hidden at that point.

### This PR closes the following issues...

N/A

### Does this PR require the Docs to be updated?

Nope

### Does this PR require new tests?

Yes

### This branch been tested on...

**Browsers:**

* [x] Chrome _version_
* [ ] Firefox _version_
* [ ] Safari _version_
* [ ] IE / Edge _version_
* [ ] iOS Browser _version_
* [ ] Android Browser _version_
