### PR TITLE
ResizeMirror should only apply changed styles

### DIFF
--- a/scripts/test/helpers/environment.js
+++ b/scripts/test/helpers/environment.js
@@ -1,3 +1,5 @@
+/* globals setImmediate */
+
 export function createSandbox(content) {
   const sandbox = document.createElement('div');
   sandbox.innerHTML = content;
@@ -15,8 +17,10 @@ export function withElementFromPoint(elementFromPoint, callback) {
 
 export const REQUEST_ANIMATION_FRAME_TIMEOUT = 15;
 
-export function waitForRequestAnimationFrame(
-  requestAnimationFrameTimeout = REQUEST_ANIMATION_FRAME_TIMEOUT,
-) {
+export function waitForRequestAnimationFrame(requestAnimationFrameTimeout = REQUEST_ANIMATION_FRAME_TIMEOUT) {
   jest.runTimersToTime(requestAnimationFrameTimeout + 1);
+}
+
+export function waitForPromisesToResolve() {
+  return new Promise((resolve) => setImmediate(resolve));
 }


### PR DESCRIPTION
### This PR improves

I noticed a flicker in the example pages that use the `ResizeMirror` plugin and noticed that we are applying unnecessary styles on the mirror.

I am adding some guards to make sure we don't re-apply same styles.

### This PR closes the following issues...

Nope

### Does this PR require the Docs to be updated?

Nope

### Does this PR require new tests?

Yes

### This branch been tested on... _(click all that apply / add new items)_

**Browsers:**

* [x] Chrome _version_
* [x] Firefox _version_
* [x] Safari _version_
* [x] IE / Edge _version_
* [x] iOS Browser _version_
* [x] Android Browser _version_
