### PR TITLE
add support for bi-directional swap animation

### DIFF
--- a/src/Plugins/SwapAnimation/README.md
+++ b/src/Plugins/SwapAnimation/README.md
@@ -37,6 +37,9 @@ The duration option allows you to specify the animation during for a single swap
 **`easingFunction {String}`**  
 The easing option allows you to specify an animation easing function. Default: `'ease-in-out'`
 
+**`horizontal {Boolean}`**
+The horizontal option allows you to set the elements to animate horizontally. Default: `false`
+
 ### Examples
 
 ```js
@@ -46,7 +49,8 @@ const sortable = new Sortable(document.querySelectorAll('ul'), {
   draggable: 'li',
   swapAnimation: {
     duration: 200,
-    easingFunction: 'ease-in-out'
+    easingFunction: 'ease-in-out',
+    horizontal: true
   },
   plugins: [Plugins.SwapAnimation]
 });
@@ -55,13 +59,11 @@ const sortable = new Sortable(document.querySelectorAll('ul'), {
 ### Plans
 
 * Add support for staggering animations
-* Add support bi-directional swap animations
 * Find cross-container animation solution
 * Add support for `Swappable` and `Droppable`
 
 ### Caveats
 
-* Only works with vertical lists
 * Only works within same container
 * Animations don't stagger
 * Only works with `Sortable`

--- a/src/Plugins/SwapAnimation/SwapAnimation.js
+++ b/src/Plugins/SwapAnimation/SwapAnimation.js
@@ -7,11 +7,13 @@ const onSortableSorted = Symbol('onSortableSorted');
  * @property {Object} defaultOptions
  * @property {Number} defaultOptions.duration
  * @property {String} defaultOptions.easingFunction
+ * @property {Boolean} defaultOptions.horizontal
  * @type {Object}
  */
 export const defaultOptions = {
   duration: 150,
   easingFunction: 'ease-in-out',
+  horizontal: false,
 };
 
 /**
@@ -96,25 +98,31 @@ export default class SwapAnimation extends AbstractPlugin {
 
 /**
  * Animates two elements
- * @param {HTMLElement} top
- * @param {HTMLElement} bottom
+ * @param {HTMLElement} from
+ * @param {HTMLElement} to
  * @param {Object} options
  * @param {Number} options.duration
  * @param {String} options.easingFunction
+ * @param {String} options.horizontal
  * @private
  */
-function animate(top, bottom, {duration, easingFunction}) {
-  const height = top.offsetHeight;
-
-  for (const element of [top, bottom]) {
+function animate(from, to, {duration, easingFunction, horizontal}) {
+  for (const element of [from, to]) {
     element.style.pointerEvents = 'none';
   }
 
-  top.style.transform = `translate3d(0, ${height}px, 0)`;
-  bottom.style.transform = `translate3d(0, -${height}px, 0)`;
+  if (horizontal) {
+    const width = from.offsetWidth;
+    from.style.transform = `translate3d(${width}px, 0, 0)`;
+    to.style.transform = `translate3d(-${width}px, 0, 0)`;
+  } else {
+    const height = from.offsetHeight;
+    from.style.transform = `translate3d(0, ${height}px, 0)`;
+    to.style.transform = `translate3d(0, -${height}px, 0)`;
+  }
 
   requestAnimationFrame(() => {
-    for (const element of [top, bottom]) {
+    for (const element of [from, to]) {
       element.addEventListener('transitionend', resetElementOnTransitionEnd);
       element.style.transition = `transform ${duration}ms ${easingFunction}`;
       element.style.transform = '';


### PR DESCRIPTION
### This PR implements or fixes... _(explain your changes)_

The SwapAnimation plugin does not currently support animating elements that are swapped horizontally. This PR adds support for that, which was a planned feature.

Documentation updates included.

### This branch been tested on... _(click all that apply / add new items)_

**Browsers:**

* [x] Chrome 67
* [ ] Firefox _version_
* [x] Safari 11
* [ ] IE / Edge _version_
* [ ] iOS Browser _version_
* [ ] Android Browser _version_
