### PR TITLE
* added mapTarget option to MouseEvent:

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@shopify/draggable",
+  "name": "@matiskiba/draggable",
   "version": "1.0.0-beta.7",
   "private": false,
   "license": "MIT",

--- a/src/Draggable/Sensors/MouseSensor/MouseSensor.js
+++ b/src/Draggable/Sensors/MouseSensor/MouseSensor.js
@@ -76,7 +76,8 @@ export default class MouseSensor extends Sensor {
 
     document.addEventListener('mouseup', this[onMouseUp]);
 
-    const target = document.elementFromPoint(event.clientX, event.clientY);
+    const target = (this.options.mapTarget?this.options.mapTarget:(htmlElement)=>htmlElement)(document.elementFromPoint(event.clientX, event.clientY));
+    
     const container = closest(target, this.containers);
 
     if (!container) {


### PR DESCRIPTION
**Note (1)**: I have tested this solution. It works very well.
**Note (2)**: for my development environment I had to change and commit package.json. Obviously the pull request does not need to include this part. I am unsure how to create the pull request without this part.

  - this options allows the mapping of target dom element to different element. To handle cases where the drag handle is outside the dragged dom tree.
    example: the handle is inside a floating menu. for z-index and position related issues, the floating menu is directly under <body>. Thus the regular handle mechanism will not be sufficient.

> Thank you for submitting a pull request! Please make sure you have read the [contribution guidelines](https://github.com/Shopify/draggable/blob/master/CONTRIBUTING.md) before proceeding.

### This PR implements or fixes... _(explain your changes)_

…

### This PR closes the following issues... _(if applicable)_

…

### Does this PR require the Docs to be updated?

…

### Does this PR require new tests?

…

### This branch been tested on... _(click all that apply / add new items)_

**Browsers:**

* [ ] Chrome _version_
* [ ] Firefox _version_
* [ ] Safari _version_
* [ ] IE / Edge _version_
* [ ] iOS Browser _version_
* [ ] Android Browser _version_
