### PR TITLE
Fix build errors on windows

### DIFF
--- a/examples/package.json
+++ b/examples/package.json
@@ -17,16 +17,13 @@
   "bugs": {
     "url": "https://github.com/Shopify/draggable/issues"
   },
-  "config": {
-    "tools": "--require babel-register --gulpfile tools"
-  },
   "scripts": {
     "clean": "rimraf dist bundle-report.html",
-    "views": "gulp views $npm_package_config_tools",
-    "scripts": "gulp scripts $npm_package_config_tools",
-    "styles": "gulp styles $npm_package_config_tools",
-    "start": "gulp start $npm_package_config_tools",
-    "build": "yarn run clean && gulp build $npm_package_config_tools",
+    "views": "gulp views --require babel-register --gulpfile tools",
+    "scripts": "gulp scripts --require babel-register --gulpfile tools",
+    "styles": "gulp styles --require babel-register --gulpfile tools",
+    "start": "gulp start --require babel-register --gulpfile tools",
+    "build": "yarn run clean && gulp build --require babel-register --gulpfile tools",
     "build:prod": "NODE_ENV=production yarn run build",
     "lint:scss": "stylelint './src/**/*.scss'",
     "prettier:scss": "prettier-stylelint './src/**/*.scss' --write -q",


### PR DESCRIPTION
This PR attempts to resolve https://github.com/Shopify/draggable/issues/225

As @soakit pointed out, it appears `$npm` config vars are not supported on Windows? That or there is something funky with how I'm using them that just does not jive on a Windows OS.

I'd love to have this tested on a few different Windows machines before shipping and closing the original issue.

@buddyy93 / @daditangs / @lexected would you be able to checkout this branch and try running `yarn` please?

**You may need to do a thorough rebuild:**
1. delete both `yarn.lock` files
2. delete both `node_module` folders
3. from root `draggable` folder, run `yarn cache clean`
4. run `yarn` in root `draggable` folder
5. `cd examples && yarn`