### PR TITLE
TS: Export DraggableOptions Interface

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -98,7 +98,7 @@ declare module '@shopify/draggable' {
 
     export type DraggableContainer = HTMLElement | HTMLElement[] | NodeList;
 
-    interface DraggableOptions {
+    export interface DraggableOptions {
         draggable?: string;
         handle?: string | NodeList | HTMLElement[] | HTMLElement | ((currentElement: HTMLElement) => HTMLElement);
         delay?: number;


### PR DESCRIPTION
Export `DraggableOptions` interface to be used when building utilities in top of Draggable.