### PR TITLE
Improve Droppable documentation and example

### DIFF
--- a/src/Droppable/README.md
+++ b/src/Droppable/README.md
@@ -2,6 +2,8 @@
 
 Droppable is built on top of Draggable and allows you to declare draggable and droppable elements via options.
 Droppable fires two events on top of the draggable events: `droppable:dropped` and `droppable:returned`.
+Droppable elements must begin in an occupied dropzone (see below, [Classes](#classes) and example),
+so they may returned if the drag is canceled or returned.
 
 ### Import
 
@@ -23,11 +25,11 @@ import Droppable from '@shopify/draggable/lib/droppable';
 
 ### API
 
-Check out [Draggables API](../Draggable#api) for the base API
+Check out [Draggable API](../Draggable#api) for the base API
 
 ### Options
 
-Check out [Draggables options](../Draggable#options) for the base options
+Check out [Draggable options](../Draggable#options) for the base options
 
 **`dropzone {String|HTMLElement[]|NodeList|Function}`**
 A css selector string, an array of elements, a NodeList or a function returning elements for dropzone
@@ -35,7 +37,7 @@ elements within the `containers`.
 
 ### Events
 
-Check out [Draggables events](../Draggable#events) for base events
+Check out [Draggable events](../Draggable#events) for the base events
 
 | Name                                      | Description                                                     | Cancelable | Cancelable action |
 | ----------------------------------------- | --------------------------------------------------------------- | ---------- | ----------------- |
@@ -47,23 +49,41 @@ Check out [Draggables events](../Draggable#events) for base events
 
 ### Classes
 
-Check out [Draggables class identifiers](../Draggable#classes)
+Check out [Draggable class identifiers](../Draggable#classes) for the base class identifiers
 
-| Name                 | Description                                                                              | Default                         |
-| -------------------- | ---------------------------------------------------------------------------------------- | ------------------------------- |
-| `droppable:active`   | Class added to the droppable container _(dropzone)_ when drag starts                     | `draggable-droppable--active`   |
-| `droppable:occupied` | Class added to the droppable container _(dropzone)_ when it contains a draggable element | `draggable-droppable--occupied` |
+| Name                 | Description                                                                    | Default                         |
+| -------------------- | ------------------------------------------------------------------------------ | ------------------------------- |
+| `droppable:active`   | Class added to the unoccupied dropzone elements when drag starts               | `draggable-droppable--active`   |
+| `droppable:occupied` | Class added to the dropzone element when it contains a draggable element       | `draggable-droppable--occupied` |
 
 ### Example
 
-This sample code will make list items draggable and allows to drop them inside another element:
+This sample HTML and JavaScript will make `.item` elements draggable and droppable among all `.dropzone` elements:
+
+```html
+<div class="container">
+  <div class="dropzone draggable-dropzone--occupied"><div class="item">A</div></div>
+  <div class="dropzone draggable-dropzone--occupied"><div class="item">B</div></div>
+  <div class="dropzone draggable-dropzone--occupied"><div class="item">C</div></div>
+</div>
+
+<div class="container">
+  <div class="dropzone"></div>
+</div>
+
+<style>
+  .item { height: 100%; }
+  .dropzone { outline: solid 1px; height: 50px; }
+  .draggable-dropzone--occupied { background: lightgreen; }
+</style>
+```
 
 ```js
 import { Droppable } from '@shopify/draggable';
 
-const droppable = new Droppable(document.querySelectorAll('ul'), {
-  draggable: 'li',
-  dropzone: '#dropzone'
+const droppable = new Droppable(document.querySelectorAll('.container'), {
+  draggable: '.item',
+  dropzone: '.dropzone'
 });
 
 droppable.on('droppable:dropped', () => console.log('droppable:dropped'));


### PR DESCRIPTION
The Droppable documentation does not mention Draggable items must begin in an occupied dropzone.

Also, in my opinion, the provided example is misleading and does not work as-is.

First, it specifies the dropzone using a CSS id (`#dropzone`), suggesting there is only one dropzone.  In fact, there must be many dropzones because all draggables must begin in a dropzone.

Second, although not a breaking problem, it uses `li` elements as the draggables, which will yield invalid HTML after dropping, unless the dropzone element(s) are `ul`, `ol` or `menu` of course; so it is a strange choice, in my opinion.

If the idea behind the example had been to create a "re-arrangable" `ul`, I thought it might be minimally modified by changing the dropzone from `#dropzone` to `.dropzone`:

```html
<ul>
  <li class="dropzone draggable-dropzone--occupied">A</li>
  <li class="dropzone draggable-dropzone--occupied">B</li>
  <li class="dropzone"></li>
</ul>
```
```js
const droppable = new window.Draggable.Droppable(document.querySelectorAll('ul'), {
  draggable: 'li',
  dropzone: '.dropzone'
});

droppable.on('droppable:dropped', () => console.log('droppable:dropped'));
droppable.on('droppable:returned', () => console.log('droppable:returned'));
```

However, a `HierarchyRequestError: Node cannot be inserted at the specified point in the hierarchy` results when dropping `A` or `B` onto the empty `li` dropzone, and the dragging node is lost.

I have adjusted the example by including actual HTML so it may be used nearly copy-paste and changing the container and draggable element selectors to be class-based.  I am guessing an example using `div` elements between containers is more closely aligned with common usage.

I have included CSS to make the example clearer for the reader when actually used interactively, but I wrote it as one-liners so the README doesn't contain too much visual noise unrelated to Droppable functionality.  The CSS is not perfect, because Droppable does not remove the `--occupied` class on the original dropzone during drag, so the background remains.  Perhaps Droppable should remove that class?  To visually indicate an empty dropzone, I would need to pseudo-CSS "--occupied && not(has-child(-mirror)", to eliminate the "being-dragged" dropzone by testing for the the mirror element.  This seems a bit much for a simple demonstration.

Having spent several hours trying to use Droppable, I was filing a new issue with a CodePen reproducer, when the GitHub beta feature "related issues" turned up #85, #213 and #258 .

Hooray for the related issues beta. :)