### PR TITLE
Fix bi-directional layout animation

### DIFF
--- a/src/Plugins/SwapAnimation/README.md
+++ b/src/Plugins/SwapAnimation/README.md
@@ -49,8 +49,7 @@ const sortable = new Sortable(document.querySelectorAll('ul'), {
   draggable: 'li',
   swapAnimation: {
     duration: 200,
-    easingFunction: 'ease-in-out',
-    horizontal: true
+    easingFunction: 'ease-in-out'
   },
   plugins: [Plugins.SwapAnimation]
 });

--- a/src/Plugins/SwapAnimation/SwapAnimation.js
+++ b/src/Plugins/SwapAnimation/SwapAnimation.js
@@ -13,7 +13,6 @@ const onSortableSorted = Symbol('onSortableSorted');
 export const defaultOptions = {
   duration: 150,
   easingFunction: 'ease-in-out',
-  horizontal: false,
 };
 
 /**
@@ -103,23 +102,28 @@ export default class SwapAnimation extends AbstractPlugin {
  * @param {Object} options
  * @param {Number} options.duration
  * @param {String} options.easingFunction
- * @param {String} options.horizontal
  * @private
  */
-function animate(from, to, {duration, easingFunction, horizontal}) {
+function animate(from, to, {duration, easingFunction}) {
   for (const element of [from, to]) {
     element.style.pointerEvents = 'none';
   }
 
-  if (horizontal) {
-    const width = from.offsetWidth;
-    from.style.transform = `translate3d(${width}px, 0, 0)`;
-    to.style.transform = `translate3d(-${width}px, 0, 0)`;
-  } else {
-    const height = from.offsetHeight;
-    from.style.transform = `translate3d(0, ${height}px, 0)`;
-    to.style.transform = `translate3d(0, -${height}px, 0)`;
-  }
+  const fromRect = from.getBoundingClientRect();
+  const toRect = to.getBoundingClientRect();
+
+  /* 
+    Calculate the displacement for the given move.
+    Here we could also calculate the inverted scale and opacity if needed.
+    Using this technique we can avoid specifying the direction of the swap and
+    let the browser naturally animate based on layout (particularly useful for flex, grid, and floating layouts)
+    Inspired by FLIP (https://aerotwist.com/blog/flip-your-animations/)
+  */
+  const dx = fromRect.left - toRect.left;
+  const dy = fromRect.top - toRect.top;
+
+  to.style.transform = `translate3d(${dx}px, ${dy}px, 0)`;
+  from.style.transform = `translate3d(${-dx}px, ${-dy}px, 0)`;
 
   requestAnimationFrame(() => {
     for (const element of [from, to]) {

--- a/src/Plugins/SwapAnimation/SwapAnimation.js
+++ b/src/Plugins/SwapAnimation/SwapAnimation.js
@@ -86,11 +86,7 @@ export default class SwapAnimation extends AbstractPlugin {
 
     // Can be done in a separate frame
     this.lastAnimationFrame = requestAnimationFrame(() => {
-      if (oldIndex >= newIndex) {
-        animate(source, over, this.options);
-      } else {
-        animate(over, source, this.options);
-      }
+      animate(source, over, this.options);
     });
   }
 }


### PR DESCRIPTION
Currently the animation plugin requires the implementation to specify a flow direction via a `horizontal` property on the configuration object. Unfortunately this method doesn't account for multi-directional layouts using flexbox, grid or floating elements.

### This PR implements or fixes...
Adds animation for elements in any layout without specifying a flow direction. 

This is made possible by getting a snapshot of the location of two elements, inverting their position and animating back to their natural position in the layout.

The `horizontal` property is also no longer required and has been removed.

### Does this PR require the Docs to be updated?
Yes. Docs have been updated as part of this PR.

### Does this PR require new tests?
No.

### This branch been tested on...
**Browsers:**

* [x] Chrome 72.0.3626.121
* [x] Firefox 65.0.2
* [x] IE / Edge 44.17763.1.0
