### PR TITLE
Add mirror threshold options

### DIFF
--- a/src/Draggable/Plugins/Mirror/Mirror.js
+++ b/src/Draggable/Plugins/Mirror/Mirror.js
@@ -32,6 +32,8 @@ export const defaultOptions = {
   yAxis: true,
   cursorOffsetX: null,
   cursorOffsetY: null,
+  thresholdX: null,
+  thresholdY: null,
 };
 
 /**
@@ -140,6 +142,12 @@ export default class Mirror extends AbstractPlugin {
 
     const {source, originalSource, sourceContainer, sensorEvent} = dragEvent;
 
+    // Last sensor position of mirror move
+    this.lastMirrorMovedClient = {
+      x: sensorEvent.clientX,
+      y: sensorEvent.clientY
+    };
+
     const mirrorCreateEvent = new MirrorCreateEvent({
       source,
       originalSource,
@@ -187,6 +195,28 @@ export default class Mirror extends AbstractPlugin {
 
     const {source, originalSource, sourceContainer, sensorEvent} = dragEvent;
 
+    let passedThreshX = true, passedThreshY = true;
+
+    if (this.options.thresholdX || this.options.thresholdY) {
+      const {x: lastX, y: lastY} = this.lastMirrorMovedClient;
+
+      if (Math.abs(lastX - sensorEvent.clientX) < this.options.thresholdX) {
+        passedThreshX = false;
+      } else {
+        this.lastMirrorMovedClient.x = sensorEvent.clientX;
+      }
+
+      if (Math.abs(lastY - sensorEvent.clientY) < this.options.thresholdY) {
+        passedThreshY = false;
+      } else {
+        this.lastMirrorMovedClient.y = sensorEvent.clientY;
+      }
+
+      if (!passedThreshX && !passedThreshY) {
+        return;
+      }
+    }
+
     const mirrorMoveEvent = new MirrorMoveEvent({
       source,
       originalSource,
@@ -194,6 +224,8 @@ export default class Mirror extends AbstractPlugin {
       sensorEvent,
       dragEvent,
       mirror: this.mirror,
+      passedThreshX,
+      passedThreshY,
     });
 
     this.draggable.trigger(mirrorMoveEvent);
@@ -248,6 +280,8 @@ export default class Mirror extends AbstractPlugin {
       this.mirrorOffset = mirrorOffset;
       this.initialX = initialX;
       this.initialY = initialY;
+      this.lastMovedX = initialX;
+      this.lastMovedY = initialY;
       return {mirrorOffset, initialX, initialY, ...args};
     };
 
@@ -258,6 +292,8 @@ export default class Mirror extends AbstractPlugin {
       mirrorClass,
       scrollOffset: this.scrollOffset,
       options: this.options,
+      passedThreshX: true,
+      passedThreshY: true,
     };
 
     return (
@@ -284,6 +320,13 @@ export default class Mirror extends AbstractPlugin {
       return null;
     }
 
+    const setState = ({ lastMovedX, lastMovedY, ...args }) => {
+      this.lastMovedX = lastMovedX;
+      this.lastMovedY = lastMovedY;
+
+      return { lastMovedX, lastMovedY, ...args };
+    };
+
     const initialState = {
       mirror: mirrorEvent.mirror,
       sensorEvent: mirrorEvent.sensorEvent,
@@ -292,9 +335,13 @@ export default class Mirror extends AbstractPlugin {
       initialX: this.initialX,
       initialY: this.initialY,
       scrollOffset: this.scrollOffset,
+      passedThreshX: mirrorEvent.passedThreshX,
+      passedThreshY: mirrorEvent.passedThreshY,
+      lastMovedX: this.lastMovedX,
+      lastMovedY: this.lastMovedY,
     };
 
-    return Promise.resolve(initialState).then(positionMirror({raf: true}));
+    return Promise.resolve(initialState).then(positionMirror({raf: true})).then(setState);
   }
 
   /**
@@ -432,7 +479,7 @@ function removeMirrorID({mirror, ...args}) {
  * @private
  */
 function positionMirror({withFrame = false, initial = false} = {}) {
-  return ({mirror, sensorEvent, mirrorOffset, initialY, initialX, scrollOffset, options, ...args}) => {
+  return ({mirror, sensorEvent, mirrorOffset, initialY, initialX, scrollOffset, options, passedThreshX, passedThreshY, lastMovedX, lastMovedY, ...args}) => {
     return withPromise(
       (resolve) => {
         const result = {
@@ -444,8 +491,8 @@ function positionMirror({withFrame = false, initial = false} = {}) {
         };
 
         if (mirrorOffset) {
-          const x = sensorEvent.clientX - mirrorOffset.left - scrollOffset.x;
-          const y = sensorEvent.clientY - mirrorOffset.top - scrollOffset.y;
+          const x = passedThreshX ? sensorEvent.clientX - mirrorOffset.left - scrollOffset.x : lastMovedX;
+          const y = passedThreshY ? sensorEvent.clientY - mirrorOffset.top - scrollOffset.y : lastMovedY;
 
           if ((options.xAxis && options.yAxis) || initial) {
             mirror.style.transform = `translate3d(${x}px, ${y}px, 0)`;
@@ -459,6 +506,9 @@ function positionMirror({withFrame = false, initial = false} = {}) {
             result.initialX = x;
             result.initialY = y;
           }
+
+          result.lastMovedX = x;
+          result.lastMovedY = y;
         }
 
         resolve(result);

--- a/src/Draggable/Plugins/Mirror/Mirror.js
+++ b/src/Draggable/Plugins/Mirror/Mirror.js
@@ -507,8 +507,14 @@ function positionMirror({withFrame = false, initial = false} = {}) {
         };
 
         if (mirrorOffset) {
-          const x = passedThreshX ? sensorEvent.clientX - mirrorOffset.left - scrollOffset.x : lastMovedX;
-          const y = passedThreshY ? sensorEvent.clientY - mirrorOffset.top - scrollOffset.y : lastMovedY;
+          const x = passedThreshX
+            ? Math.round((sensorEvent.clientX - mirrorOffset.left - scrollOffset.x) / (options.thresholdX || 1)) *
+              (options.thresholdX || 1)
+            : lastMovedX;
+          const y = passedThreshY
+            ? Math.round((sensorEvent.clientY - mirrorOffset.top - scrollOffset.y) / (options.thresholdY || 1)) *
+              (options.thresholdY || 1)
+            : lastMovedY;
 
           if ((options.xAxis && options.yAxis) || initial) {
             mirror.style.transform = `translate3d(${x}px, ${y}px, 0)`;

--- a/src/Draggable/Plugins/Mirror/Mirror.js
+++ b/src/Draggable/Plugins/Mirror/Mirror.js
@@ -145,7 +145,7 @@ export default class Mirror extends AbstractPlugin {
     // Last sensor position of mirror move
     this.lastMirrorMovedClient = {
       x: sensorEvent.clientX,
-      y: sensorEvent.clientY
+      y: sensorEvent.clientY,
     };
 
     const mirrorCreateEvent = new MirrorCreateEvent({
@@ -195,7 +195,8 @@ export default class Mirror extends AbstractPlugin {
 
     const {source, originalSource, sourceContainer, sensorEvent} = dragEvent;
 
-    let passedThreshX = true, passedThreshY = true;
+    let passedThreshX = true;
+    let passedThreshY = true;
 
     if (this.options.thresholdX || this.options.thresholdY) {
       const {x: lastX, y: lastY} = this.lastMirrorMovedClient;
@@ -320,11 +321,11 @@ export default class Mirror extends AbstractPlugin {
       return null;
     }
 
-    const setState = ({ lastMovedX, lastMovedY, ...args }) => {
+    const setState = ({lastMovedX, lastMovedY, ...args}) => {
       this.lastMovedX = lastMovedX;
       this.lastMovedY = lastMovedY;
 
-      return { lastMovedX, lastMovedY, ...args };
+      return {lastMovedX, lastMovedY, ...args};
     };
 
     const initialState = {
@@ -341,7 +342,9 @@ export default class Mirror extends AbstractPlugin {
       lastMovedY: this.lastMovedY,
     };
 
-    return Promise.resolve(initialState).then(positionMirror({raf: true})).then(setState);
+    return Promise.resolve(initialState)
+      .then(positionMirror({raf: true}))
+      .then(setState);
   }
 
   /**
@@ -479,7 +482,20 @@ function removeMirrorID({mirror, ...args}) {
  * @private
  */
 function positionMirror({withFrame = false, initial = false} = {}) {
-  return ({mirror, sensorEvent, mirrorOffset, initialY, initialX, scrollOffset, options, passedThreshX, passedThreshY, lastMovedX, lastMovedY, ...args}) => {
+  return ({
+    mirror,
+    sensorEvent,
+    mirrorOffset,
+    initialY,
+    initialX,
+    scrollOffset,
+    options,
+    passedThreshX,
+    passedThreshY,
+    lastMovedX,
+    lastMovedY,
+    ...args
+  }) => {
     return withPromise(
       (resolve) => {
         const result = {

--- a/src/Draggable/Plugins/Mirror/MirrorEvent/MirrorEvent.js
+++ b/src/Draggable/Plugins/Mirror/MirrorEvent/MirrorEvent.js
@@ -141,6 +141,24 @@ export class MirrorMoveEvent extends MirrorEvent {
   get mirror() {
     return this.data.mirror;
   }
+
+  /**
+   * Sensor has exceeded mirror's threshold on x axis
+   * @type {Boolean}
+   * @readonly
+   */
+  get passedThreshX() {
+    return this.data.passedThreshX;
+  }
+
+  /**
+   * Sensor has exceeded mirror's threshold on y axis
+   * @type {Boolean}
+   * @readonly
+   */
+  get passedThreshY() {
+    return this.data.passedThreshY;
+  }
 }
 
 /**

--- a/src/Draggable/Plugins/Mirror/MirrorEvent/README.md
+++ b/src/Draggable/Plugins/Mirror/MirrorEvent/README.md
@@ -96,6 +96,13 @@ The mirror follows your mouse/touch movements.
 Read-only property for the mirror element, which is also a copy of the `originalSource` element.
 The mirror follows your mouse/touch movements.
 
+**`mirrorEvent.passedThreshX: Booolean`**  
+Read-only property for whether or not the mirror's threshold has been exceeded in the x axis.
+
+**`mirrorEvent.passedThreshY: Booolean`**  
+Read-only property for whether or not the mirror's threshold has been exceeded in the y axis.
+
+
 ## MirrorDestroyEvent
 
 `MirrorDestroyEvent` gets triggered before the mirror gets removed from the DOM.

--- a/src/Draggable/Plugins/Mirror/README.md
+++ b/src/Draggable/Plugins/Mirror/README.md
@@ -32,6 +32,12 @@ this is not where the source will be placed, only the temporary mirror element, 
 that follows your cursor as you drag. You can specify a css selector, a HTMLElement or a function
 that returns a HTMLElement. Default is the source parent element.
 
+**`thresholdX {Number|null}`**
+Defining this sets a threshold that must be exceeded by the mouse for the mirror to move on the x axis. Default: `null`
+
+**`thresholdY {Number|null}`**
+Defining this sets a threshold that must be exceeded by the mouse for the mirror to move on the y axis. Default: `null`
+
 ### Events
 
 | Name                                | Description                                           | Cancelable | Cancelable action        |

--- a/src/Draggable/Plugins/Mirror/tests/Mirror.test.js
+++ b/src/Draggable/Plugins/Mirror/tests/Mirror.test.js
@@ -270,6 +270,56 @@ describe('Mirror', () => {
     releaseMouse(draggable.source);
   });
 
+  it('moves mirror only when past `thresholdX` or `thresholdY`', async () => {
+    draggable = new Draggable(container, {
+      ...draggableOptions,
+      mirror: {
+        thresholdX: 10,
+        thresholdY: 50,
+      },
+    });
+
+    clickMouse(draggableElement);
+    waitForDragDelay();
+    waitForRequestAnimationFrame();
+
+    await waitForPromisesToResolve();
+
+    const mirrorElement = document.querySelector('.draggable-mirror');
+
+    moveMouse(document.body, {
+      clientX: 5,
+      clientY: 10,
+    });
+
+    await waitForPromisesToResolve();
+    waitForRequestAnimationFrame();
+
+    expect(mirrorElement.style.transform).toBe('translate3d(0px, 0px, 0)');
+
+    moveMouse(document.body, {
+      clientX: 10,
+      clientY: 40,
+    });
+
+    await waitForPromisesToResolve();
+    waitForRequestAnimationFrame();
+
+    expect(mirrorElement.style.transform).toBe('translate3d(10px, 0px, 0)');
+
+    moveMouse(document.body, {
+      clientX: 100,
+      clientY: 100,
+    });
+
+    await waitForPromisesToResolve();
+    waitForRequestAnimationFrame();
+
+    expect(mirrorElement.style.transform).toBe('translate3d(100px, 100px, 0)');
+
+    releaseMouse(draggable.source);
+  });
+
   it('prevents mirror movement when `mirror:move` gets canceled', async () => {
     draggable = new Draggable(container, draggableOptions);
 


### PR DESCRIPTION
### This PR implements or fixes...
`thresholdX` and `thresholdY` options for the mirror plugin, allowing a sort of 'grid' effect while dragging the mirror

### This PR closes the following issues...
#320

### Does this PR require the Docs to be updated?
Yes, updated

### Does this PR require new tests?
Yes, added

### This branch been tested on...

**Browsers:**

* [x] Chrome 74.0.3729.131
* [x] Chrome 72.0.3626.121 for Android
* [x] Firefox 65.0.2
* [x] Microsoft Edge 42.17134.1.0