### PR TITLE
Add distance option

### DIFF
--- a/src/Draggable/Draggable.js
+++ b/src/Draggable/Draggable.js
@@ -48,6 +48,7 @@ export const defaultOptions = {
   draggable: '.draggable-source',
   handle: null,
   delay: 100,
+  distance: 0,
   placedTimeout: 800,
   plugins: [],
   sensors: [],

--- a/src/Draggable/README.md
+++ b/src/Draggable/README.md
@@ -80,6 +80,10 @@ on the entire element. Default: `null`
 If you want to delay a drag start you can specify delay in milliseconds. This can be useful
 for draggable elements within scrollable containers. Default: `100`
 
+**`distance {Number}`**  
+The distance you want the pointer to have moved before drag starts. This can be useful
+for clickable draggable elements, such as links. Default: `0`
+
 **`plugins {Plugin[]}`**  
 Plugins add behaviour to Draggable by hooking into its life cycle, e.g. one of the default
 plugins controls the mirror movement. Default: `[]`

--- a/src/Draggable/Sensors/DragSensor/DragSensor.js
+++ b/src/Draggable/Sensors/DragSensor/DragSensor.js
@@ -161,6 +161,8 @@ export default class DragSensor extends Sensor {
     this.trigger(container, dragStopEvent);
 
     this.dragging = false;
+    this.delayOver = false;
+    this.startEvent = null;
 
     this[reset]();
   }
@@ -205,7 +207,10 @@ export default class DragSensor extends Sensor {
       return;
     }
 
+    this.startEvent = event;
+
     this.mouseDownTimeout = setTimeout(() => {
+      this.delayOver = true;
       target.draggable = true;
       this.draggableElement = target;
     }, this.options.delay);

--- a/src/Draggable/Sensors/DragSensor/README.md
+++ b/src/Draggable/Sensors/DragSensor/README.md
@@ -28,7 +28,7 @@ This value will delay touch start
 ### Known issues
 
 The drag sensor uses the native Drag and Drop API and therefor Draggable does not create
-a mirror. This means there is less control over the mirror
+a mirror. This means there is less control over the mirror.
 
 ### Example
 
@@ -42,3 +42,7 @@ const draggable = new Draggable(containers, {
 // Remove default mouse sensor
 draggable.removeSensor(Sensors.MouseSensor);
 ```
+
+### Caveats
+
+- The `distance` option will not work with this sensor.

--- a/src/Draggable/Sensors/MouseSensor/MouseSensor.js
+++ b/src/Draggable/Sensors/MouseSensor/MouseSensor.js
@@ -1,4 +1,4 @@
-import {closest} from 'shared/utils';
+import {closest, distance} from 'shared/utils';
 import Sensor from '../Sensor';
 import {DragStartSensorEvent, DragMoveSensorEvent, DragStopSensorEvent} from '../SensorEvent';
 
@@ -6,6 +6,8 @@ const onContextMenuWhileDragging = Symbol('onContextMenuWhileDragging');
 const onMouseDown = Symbol('onMouseDown');
 const onMouseMove = Symbol('onMouseMove');
 const onMouseUp = Symbol('onMouseUp');
+const startDrag = Symbol('startDrag');
+const onDistanceChange = Symbol('onDistanceChange');
 
 /**
  * This sensor picks up native browser mouse events and dictates drag operations
@@ -24,30 +26,18 @@ export default class MouseSensor extends Sensor {
     super(containers, options);
 
     /**
-     * Indicates if mouse button is still down
-     * @property mouseDown
-     * @type {Boolean}
-     */
-    this.mouseDown = false;
-
-    /**
      * Mouse down timer which will end up triggering the drag start operation
      * @property mouseDownTimeout
      * @type {Number}
      */
     this.mouseDownTimeout = null;
 
-    /**
-     * Indicates if context menu has been opened during drag operation
-     * @property openedContextMenu
-     * @type {Boolean}
-     */
-    this.openedContextMenu = false;
-
     this[onContextMenuWhileDragging] = this[onContextMenuWhileDragging].bind(this);
     this[onMouseDown] = this[onMouseDown].bind(this);
     this[onMouseMove] = this[onMouseMove].bind(this);
     this[onMouseUp] = this[onMouseUp].bind(this);
+    this[startDrag] = this[startDrag].bind(this);
+    this[onDistanceChange] = this[onDistanceChange].bind(this);
   }
 
   /**
@@ -74,10 +64,12 @@ export default class MouseSensor extends Sensor {
       return;
     }
 
-    document.addEventListener('mouseup', this[onMouseUp]);
+    this.startEvent = event;
 
-    const target = document.elementFromPoint(event.clientX, event.clientY);
-    const container = closest(target, this.containers);
+    document.addEventListener('mouseup', this[onMouseUp]);
+    document.addEventListener('mousemove', this[onDistanceChange]);
+
+    const container = closest(event.target, this.containers);
 
     if (!container) {
       return;
@@ -85,32 +77,52 @@ export default class MouseSensor extends Sensor {
 
     document.addEventListener('dragstart', preventNativeDragStart);
 
-    this.mouseDown = true;
-
-    clearTimeout(this.mouseDownTimeout);
+    this.currentContainer = container;
     this.mouseDownTimeout = setTimeout(() => {
-      if (!this.mouseDown) {
-        return;
-      }
-
-      const dragStartEvent = new DragStartSensorEvent({
-        clientX: event.clientX,
-        clientY: event.clientY,
-        target,
-        container,
-        originalEvent: event,
-      });
-
-      this.trigger(container, dragStartEvent);
-
-      this.currentContainer = container;
-      this.dragging = !dragStartEvent.canceled();
-
-      if (this.dragging) {
-        document.addEventListener('contextmenu', this[onContextMenuWhileDragging]);
-        document.addEventListener('mousemove', this[onMouseMove]);
-      }
+      this.delayOver = true;
+      if (this.distance < this.options.distance) return;
+      this[startDrag]();
     }, this.options.delay);
+  }
+
+  /**
+   * Start the drag
+   * @private
+   */
+  [startDrag]() {
+    const startEvent = this.startEvent;
+    const container = this.currentContainer;
+
+    const dragStartEvent = new DragStartSensorEvent({
+      clientX: startEvent.clientX,
+      clientY: startEvent.clientY,
+      target: startEvent.target,
+      container,
+      originalEvent: startEvent,
+    });
+
+    this.trigger(this.currentContainer, dragStartEvent);
+
+    this.dragging = !dragStartEvent.canceled();
+
+    if (this.dragging) {
+      document.addEventListener('contextmenu', this[onContextMenuWhileDragging], true);
+      document.addEventListener('mousemove', this[onMouseMove]);
+    }
+  }
+
+  /**
+   * Detect change in distance
+   * @private
+   * @param {Event} event - Mouse move event
+   */
+  [onDistanceChange](event) {
+    if (this.dragging) return;
+    this.distance = distance(this.startEvent.pageX, this.startEvent.pageY, event.pageX, event.pageY);
+
+    if (this.delayOver && this.distance >= this.options.distance) {
+      this[startDrag]();
+    }
   }
 
   /**
@@ -142,15 +154,15 @@ export default class MouseSensor extends Sensor {
    * @param {Event} event - Mouse up event
    */
   [onMouseUp](event) {
-    this.mouseDown = Boolean(this.openedContextMenu);
+    clearTimeout(this.mouseDownTimeout);
 
-    if (this.openedContextMenu) {
-      this.openedContextMenu = false;
+    if (event.button !== 0) {
       return;
     }
 
     document.removeEventListener('mouseup', this[onMouseUp]);
     document.removeEventListener('dragstart', preventNativeDragStart);
+    document.removeEventListener('mousemove', this[onDistanceChange]);
 
     if (!this.dragging) {
       return;
@@ -168,11 +180,14 @@ export default class MouseSensor extends Sensor {
 
     this.trigger(this.currentContainer, dragStopEvent);
 
-    document.removeEventListener('contextmenu', this[onContextMenuWhileDragging]);
+    document.removeEventListener('contextmenu', this[onContextMenuWhileDragging], true);
     document.removeEventListener('mousemove', this[onMouseMove]);
 
     this.currentContainer = null;
     this.dragging = false;
+    this.distance = 0;
+    this.delayOver = false;
+    this.startEvent = null;
   }
 
   /**
@@ -182,7 +197,6 @@ export default class MouseSensor extends Sensor {
    */
   [onContextMenuWhileDragging](event) {
     event.preventDefault();
-    this.openedContextMenu = true;
   }
 }
 

--- a/src/Draggable/Sensors/MouseSensor/MouseSensor.js
+++ b/src/Draggable/Sensors/MouseSensor/MouseSensor.js
@@ -80,7 +80,9 @@ export default class MouseSensor extends Sensor {
     this.currentContainer = container;
     this.mouseDownTimeout = setTimeout(() => {
       this.delayOver = true;
-      if (this.distance < this.options.distance) return;
+      if (this.distance < this.options.distance) {
+        return;
+      }
       this[startDrag]();
     }, this.options.delay);
   }

--- a/src/Draggable/Sensors/Sensor/Sensor.js
+++ b/src/Draggable/Sensors/Sensor/Sensor.js
@@ -38,6 +38,27 @@ export default class Sensor {
      * @type {HTMLElement}
      */
     this.currentContainer = null;
+
+    /**
+     * The distance moved from the first pointer down location, no longer updated after the drag has started
+     * @property distance
+     * @type {Number}
+     */
+    this.distance = 0;
+
+    /**
+     * Indicates whether the delay has ended
+     * @property delayOver
+     * @type {Boolean}
+     */
+    this.delayOver = false;
+
+    /**
+     * The event of the initial sensor down
+     * @property startEvent
+     * @type {Event}
+     */
+    this.startEvent = null;
   }
 
   /**

--- a/src/Draggable/Sensors/TouchSensor/TouchSensor.js
+++ b/src/Draggable/Sensors/TouchSensor/TouchSensor.js
@@ -1,11 +1,12 @@
-import {closest} from 'shared/utils';
+import {closest, distance} from 'shared/utils';
 import Sensor from '../Sensor';
 import {DragStartSensorEvent, DragMoveSensorEvent, DragStopSensorEvent} from '../SensorEvent';
 
 const onTouchStart = Symbol('onTouchStart');
-const onTouchHold = Symbol('onTouchHold');
 const onTouchEnd = Symbol('onTouchEnd');
 const onTouchMove = Symbol('onTouchMove');
+const startDrag = Symbol('startDrag');
+const onDistanceChange = Symbol('onDistanceChange');
 
 /**
  * Prevents scrolling when set to true
@@ -65,9 +66,10 @@ export default class TouchSensor extends Sensor {
     this.touchMoved = false;
 
     this[onTouchStart] = this[onTouchStart].bind(this);
-    this[onTouchHold] = this[onTouchHold].bind(this);
     this[onTouchEnd] = this[onTouchEnd].bind(this);
     this[onTouchMove] = this[onTouchMove].bind(this);
+    this[startDrag] = this[startDrag].bind(this);
+    this[onDistanceChange] = this[onDistanceChange].bind(this);
   }
 
   /**
@@ -96,43 +98,64 @@ export default class TouchSensor extends Sensor {
       return;
     }
 
+    this.startEvent = event;
+
     document.addEventListener('touchmove', this[onTouchMove]);
     document.addEventListener('touchend', this[onTouchEnd]);
     document.addEventListener('touchcancel', this[onTouchEnd]);
+    document.addEventListener('touchmove', this[onDistanceChange]);
     container.addEventListener('contextmenu', onContextMenu);
 
+    if (this.options.distance) {
+      preventScrolling = true;
+    }
+
     this.currentContainer = container;
-    this.tapTimeout = setTimeout(this[onTouchHold](event, container), this.options.delay);
+    this.tapTimeout = setTimeout(() => {
+      this.delayOver = true;
+      if (this.touchMoved || this.distance < this.options.distance) return;
+      this[startDrag]();
+    }, this.options.delay);
   }
 
   /**
-   * Touch hold handler
+   * Start the drag
    * @private
-   * @param {Event} event - Touch start event
-   * @param {HTMLElement} container - Container element
    */
-  [onTouchHold](event, container) {
-    return () => {
-      if (this.touchMoved) {
-        return;
-      }
+  [startDrag]() {
+    const startEvent = this.startEvent;
+    const container = this.currentContainer;
+    const touch = startEvent.touches[0] || startEvent.changedTouches[0];
 
-      const touch = event.touches[0] || event.changedTouches[0];
-      const target = event.target;
+    const dragStartEvent = new DragStartSensorEvent({
+      clientX: touch.pageX,
+      clientY: touch.pageY,
+      target: startEvent.target,
+      container,
+      originalEvent: startEvent,
+    });
 
-      const dragStartEvent = new DragStartSensorEvent({
-        clientX: touch.pageX,
-        clientY: touch.pageY,
-        target,
-        container,
-        originalEvent: event,
-      });
+    this.trigger(this.currentContainer, dragStartEvent);
 
-      this.trigger(container, dragStartEvent);
+    this.dragging = !dragStartEvent.canceled();
+    preventScrolling = this.dragging;
+  }
 
-      this.dragging = !dragStartEvent.canceled();
-      preventScrolling = this.dragging;
-    };
+  /**
+   * Detect change in distance
+   * @private
+   * @param {Event} event - Touch move event
+   */
+  [onDistanceChange](event) {
+    if (this.dragging || !this.options.distance) return;
+    const tap = this.startEvent.touches[0] || this.startEvent.changedTouches[0];
+    const touch = event.touches[0] || event.changedTouches[0];
+
+    this.distance = distance(tap.pageX, tap.pageY, touch.pageX, touch.pageY);
+
+    if (this.delayOver && this.distance >= this.options.distance) {
+      this[startDrag]();
+    }
   }
 
   /**
@@ -173,6 +196,7 @@ export default class TouchSensor extends Sensor {
     document.removeEventListener('touchend', this[onTouchEnd]);
     document.removeEventListener('touchcancel', this[onTouchEnd]);
     document.removeEventListener('touchmove', this[onTouchMove]);
+    document.removeEventListener('touchmove', this[onDistanceChange]);
 
     if (this.currentContainer) {
       this.currentContainer.removeEventListener('contextmenu', onContextMenu);
@@ -201,6 +225,9 @@ export default class TouchSensor extends Sensor {
 
     this.currentContainer = null;
     this.dragging = false;
+    this.distance = 0;
+    this.delayOver = false;
+    this.startEvent = null;
   }
 }
 

--- a/src/Draggable/Sensors/TouchSensor/TouchSensor.js
+++ b/src/Draggable/Sensors/TouchSensor/TouchSensor.js
@@ -113,7 +113,9 @@ export default class TouchSensor extends Sensor {
     this.currentContainer = container;
     this.tapTimeout = setTimeout(() => {
       this.delayOver = true;
-      if (this.touchMoved || this.distance < this.options.distance) return;
+      if (this.touchMoved || this.distance < this.options.distance) {
+        return;
+      }
       this[startDrag]();
     }, this.options.delay);
   }
@@ -147,7 +149,10 @@ export default class TouchSensor extends Sensor {
    * @param {Event} event - Touch move event
    */
   [onDistanceChange](event) {
-    if (this.dragging || !this.options.distance) return;
+    if (this.dragging || !this.options.distance) {
+      return;
+    }
+
     const tap = this.startEvent.touches[0] || this.startEvent.changedTouches[0];
     const touch = event.touches[0] || event.changedTouches[0];
 

--- a/src/Draggable/tests/Draggable.test.js
+++ b/src/Draggable/tests/Draggable.test.js
@@ -466,7 +466,7 @@ describe('Draggable', () => {
 
     expect(call).toBeInstanceOf(DragStartEvent);
 
-    triggerEvent(draggableElement, 'mouseup');
+    triggerEvent(draggableElement, 'mouseup', {button: 0});
   });
 
   it('should trigger `drag:start` drag event on dragstart', () => {
@@ -492,7 +492,7 @@ describe('Draggable', () => {
 
     expect(call).toBeInstanceOf(DragStartEvent);
 
-    triggerEvent(draggableElement, 'mouseup');
+    triggerEvent(draggableElement, 'mouseup', {button: 0});
   });
 
   it('cleans up when `drag:start` event is canceled', () => {
@@ -555,7 +555,7 @@ describe('Draggable', () => {
 
     expect(sensorEvent.clientY).toBe(expectedClientY);
 
-    triggerEvent(draggableElement, 'mouseup');
+    triggerEvent(draggableElement, 'mouseup', {button: 0});
   });
 
   it('triggers `drag:stop` drag event on mouseup', () => {
@@ -596,7 +596,7 @@ describe('Draggable', () => {
 
     expect(newInstance.source.classList).toContain('draggable-source--is-dragging');
 
-    triggerEvent(draggableElement, 'mouseup');
+    triggerEvent(draggableElement, 'mouseup', {button: 0});
   });
 
   it('removes `source:dragging` classname from draggable element on mouseup', () => {
@@ -658,7 +658,7 @@ describe('Draggable', () => {
 
     expect(document.body.classList).toContain('draggable--is-dragging');
 
-    triggerEvent(draggableElement, 'mouseup');
+    triggerEvent(draggableElement, 'mouseup', {button: 0});
   });
 
   it('removes `body:dragging` classname from body on mouseup', () => {

--- a/src/shared/utils/distance/distance.js
+++ b/src/shared/utils/distance/distance.js
@@ -1,0 +1,11 @@
+/**
+ * Returns the distance between two points
+ * @param  {Number} x1 The X position of the first point
+ * @param  {Number} y1 The Y position of the first point
+ * @param  {Number} x2 The X position of the second point
+ * @param  {Number} y2 The Y position of the second point
+ * @return {Number}
+ */
+export default function distance(x1, y1, x2, y2) {
+  return Math.sqrt((x2 - x1) ** 2 + (y2 - y1) ** 2);
+}

--- a/src/shared/utils/distance/index.js
+++ b/src/shared/utils/distance/index.js
@@ -1,0 +1,3 @@
+import distance from './distance';
+
+export default distance;

--- a/src/shared/utils/index.js
+++ b/src/shared/utils/index.js
@@ -1,2 +1,3 @@
 export {default as closest} from './closest';
 export {default as requestNextAnimationFrame} from './requestNextAnimationFrame';
+export {default as distance} from './distance';


### PR DESCRIPTION
### This PR implements or fixes...
Implements a `distance` option, as a pixel threshold that must be passed in order for the drag to start.
I also fixed an issue with MouseSensor in which the context menu was still being allowed to open during drag.

The new distance option is impossible for DragSensor, as I know native Drag and Drop is cancelled on every browser after a certain threshold is passed and `draggable` is not yet set to `true`. Therefore this option would be completely redundant. So I listed it as a caveat in the DragSensor's README.

The delay should still work even if the `distance` option is set. Of course in this scenario, the delay will have to be completed *and* the user must have moved passed the distance in order for drag to start. For the TouchSensor, since it cancels dragging if the touch is moved during the delay, I made it such that the drag will not automatically start after the delay if the touch is moved, but it still can start if the user has moved passed the distance when the delay is over. For this to be possible, I made it so that scrolling is prevented on touchStart **only if** the `distance` option is set. This way a dragStart can be detected if the user moves passed the distance, and if the distance option is not set scrolling may function normally.
I don't expect anyone to be using these options in conjunction, but this is nonetheless the current behaviour.

I haven't done anything with the ForceTouchSensor yet, as I am not currently able to test it manually, and there aren't any unit tests written.


### This PR closes the following issues...
#250 

### Does this PR require the Docs to be updated?
Yes

### Does this PR require new tests?
No

### This branch been tested on...

**Browsers:**

* [x] Chrome 74.0.3729.169
* [x] Firefox 67
* [x] Safari Version 12.1 (14607.1.40.1.4)
* [x] IE / Edge 42.17134.1.0
* [x] Chrome 74.0.3729.136 for Android