### PR TITLE
feat: improve import safety in node #86

### DIFF
--- a/scripts/build/production.js
+++ b/scripts/build/production.js
@@ -27,6 +27,7 @@ function createBundleConfig(bundle, {analyser}) {
       library: bundle.name,
       libraryTarget: 'umd',
       umdNamedDefine: true,
+      globalObject: 'this',
     },
     optimization: {
       minimize,

--- a/src/Draggable/Sensors/TouchSensor/TouchSensor.js
+++ b/src/Draggable/Sensors/TouchSensor/TouchSensor.js
@@ -14,19 +14,23 @@ const onDistanceChange = Symbol('onDistanceChange');
  */
 let preventScrolling = false;
 
-// WebKit requires cancelable `touchmove` events to be added as early as possible
-window.addEventListener(
-  'touchmove',
-  (event) => {
-    if (!preventScrolling) {
-      return;
-    }
+const hasWindow = typeof window !== 'undefined';
 
-    // Prevent scrolling
-    event.preventDefault();
-  },
-  {passive: false},
-);
+// WebKit requires cancelable `touchmove` events to be added as early as possible
+if (hasWindow) {
+  window.addEventListener(
+    'touchmove',
+    (event) => {
+      if (!preventScrolling) {
+        return;
+      }
+
+      // Prevent scrolling
+      event.preventDefault();
+    },
+    {passive: false},
+  );
+}
 
 /**
  * This sensor picks up native browser touch events and dictates drag operations


### PR DESCRIPTION
### This PR implements or fixes... _(explain your changes)_

When I try import this package in my Vue ssr project, got several errors as 'window is not defined',  this PR tends to make sure that won't happen. 

### This PR closes the following issues... _(if applicable)_

A [similar one](https://github.com/Shopify/draggable/issues/86), but already been closed.

### This branch been tested on... _(click all that apply / add new items)_

**Browsers:**

* [ ] Chrome _version_
* [ ] Firefox _version_
* [ ] Safari _version_
* [ ] IE / Edge _version_
* [ ] iOS Browser _version_
* [ ] Android Browser _version_
