### PR TITLE
Prevent touchstart event if startEvent has already been registered

### DIFF
--- a/src/Draggable/Sensors/TouchSensor/TouchSensor.js
+++ b/src/Draggable/Sensors/TouchSensor/TouchSensor.js
@@ -92,6 +92,11 @@ export default class TouchSensor extends Sensor {
    * @param {Event} event - Touch start event
    */
   [onTouchStart](event) {
+    if (this.startEvent) {
+      event.preventDefault();
+      return;
+    }
+
     const container = closest(event.target, this.containers);
 
     if (!container) {


### PR DESCRIPTION
### This PR implements or fixes...

We used this library for a website that was being run on a kiosk. The Kiosk runs Chrome/Chromium on a system called Kioware with a large touch screen that supports multi touch. With this configuration, a strange issue popped up – namely that sometimes visitors would start dragging elements and find that the mirror elements were left behind and never removed. After some initial trouble reproducing the issue, we found that using two fingers to tap two different elements at the same time reliably reproduced the issue. See this screencast for an illustration of the issue (in it I tap multiple times with two fingers simultaneously on different draggable items): https://www.dropbox.com/s/ssyllrws4y5hgnt/Draggable%20multi%20touch%20bug.MP4?dl=0

To fix this I added a simple check in the `onTouchStart` handler that prevents the event if `this.startEvent` has already been registered. Initially I checked if `this.dragging` was truthy, but this didn't work since that property was only being set after the delay timeout callback had been run.

### This PR closes the following issues...

I didn't submit an issue (and no issue seems to have described this problem before)

### Does this PR require the Docs to be updated?

No

### Does this PR require new tests?

No

### This branch been tested on...

**Browsers:**

* [ ] Chrome _version_
* [ ] Firefox _version_
* [ ] Safari _version_
* [ ] IE / Edge _version_
* [x] iOS Browser 12.4
* [ ] Android Browser _version_
