### PR TITLE
Add changelog for v1.0.0-beta.9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## v1.0.0-beta.9 - 2019-08-26
+
+### Added
+
+* Added `distance` option
+* Added `thresholdX` and `thresholdY` mirror options
+
+### Changed
+
+* Fixes preventing of contextmenu in MouseSensor
+* Fixes SortableEvent `over` and `overContainer` giving incorrect properties
+
 ## v1.0.0-beta.8 - 2018-09-07
 
 ### Changed


### PR DESCRIPTION
### This PR Adds

`changelog` for new beta version(`v1.0.0-beta.9`) release

### Does this PR require the Docs to be updated?

No

### Does this PR require new tests?

No
