### PR TITLE
fix: reset delayOver in onMouseUp/onTouchEnd always

### DIFF
--- a/src/Draggable/Sensors/MouseSensor/MouseSensor.js
+++ b/src/Draggable/Sensors/MouseSensor/MouseSensor.js
@@ -156,6 +156,7 @@ export default class MouseSensor extends Sensor {
    * @param {Event} event - Mouse up event
    */
   [onMouseUp](event) {
+    this.delayOver = false;
     clearTimeout(this.mouseDownTimeout);
 
     if (event.button !== 0) {
@@ -188,7 +189,6 @@ export default class MouseSensor extends Sensor {
     this.currentContainer = null;
     this.dragging = false;
     this.distance = 0;
-    this.delayOver = false;
     this.startEvent = null;
   }
 

--- a/src/Draggable/Sensors/TouchSensor/TouchSensor.js
+++ b/src/Draggable/Sensors/TouchSensor/TouchSensor.js
@@ -195,6 +195,7 @@ export default class TouchSensor extends Sensor {
    * @param {Event} event - Touch end event
    */
   [onTouchEnd](event) {
+    this.delayOver = false;
     this.touchMoved = false;
     preventScrolling = false;
 
@@ -231,7 +232,6 @@ export default class TouchSensor extends Sensor {
     this.currentContainer = null;
     this.dragging = false;
     this.distance = 0;
-    this.delayOver = false;
     this.startEvent = null;
   }
 }


### PR DESCRIPTION
# fix: trigger drag:start event twice consecutively

## problem
There are two places may invoke [startDrag] method in MouseSensor(same in TouchSensor), they are all called to emit drag:start event in one start-stop cycle. An example of  error execution order:
1. dom mousedown triggered
  - [onDistanceChange] updates `distance` + check if invoke [startDrag] when dom mousemove
  - start a `MouseDownTimer`, set `delayOver` to true + check if invoke [startDrag] in the time
2. dom mouseup triggered
  -  if `MouseDownTimer` reached, but distance is too small, [startDrag] won't be invoked. So `delayOver` set true  true, `dragging` is still false now
  - detect that `dragging` is false, then [onMouseDonw] handler returned without reset `delayOver`;
3. dom mousedown trigger again
  - [onDistanceChange] will **`invoke [startDrag]`** for delayOver is true and if distance is large enough.
  - start a `MouseDownTimer`, then it will **`invoke [startDrag] angin`** for no checking of `dragging`

## solution
reset delayOver in onMouseUp/onTouchEnd always.
