### PR TITLE
refactor: MouseSensor test case update

### DIFF
--- a/src/Draggable/Sensors/MouseSensor/tests/MouseSensor.test.js
+++ b/src/Draggable/Sensors/MouseSensor/tests/MouseSensor.test.js
@@ -101,19 +101,13 @@ describe('MouseSensor', () => {
       releaseMouse(document.body);
     }
 
-    function dragFlowWithCtrlKey() {
-      clickMouse(draggableElement, {ctrlKey: true});
+    function dragFlowWithATag() {
+      clickMouse(draggableElement, {srcElement.nodeName: "A"});
       waitForDragDelay();
       releaseMouse(document.body);
     }
 
-    function dragFlowWithMetaKey() {
-      clickMouse(draggableElement, {metaKey: true});
-      waitForDragDelay();
-      releaseMouse(document.body);
-    }
-
-    [dragFlowWithRightClick, dragFlowWithCtrlKey, dragFlowWithMetaKey].forEach((dragFlow) => {
+    [dragFlowWithRightClick, dragFlowWithATag].forEach((dragFlow) => {
       expect(dragFlow).not.toHaveTriggeredSensorEvent('drag:start');
     });
   });


### PR DESCRIPTION
does not trigger `drag:start` event when right clicking or holding "ctrl + click" or "metakey + click"