### PR TITLE
Fix removing multiple event listeners of the same type

### DIFF
--- a/src/Draggable/Emitter/Emitter.js
+++ b/src/Draggable/Emitter/Emitter.js
@@ -33,15 +33,7 @@ export default class Emitter {
       return null;
     }
 
-    const copy = this.callbacks[type].slice(0);
-
-    for (let i = 0; i < copy.length; i++) {
-      if (callback === copy[i]) {
-        this.callbacks[type].splice(i, 1);
-      }
-    }
-
-    return this;
+    this.callbacks[type] = this.callbacks[type].filter(cb => cb !== callback);
   }
 
   /**

--- a/src/Draggable/Emitter/tests/Emitter.test.js
+++ b/src/Draggable/Emitter/tests/Emitter.test.js
@@ -31,15 +31,18 @@ describe('Emitter', () => {
 
   describe('#off', () => {
     it('removes a callback by event type', () => {
-      const callback = jest.fn();
+      const callbacks = [jest.fn(), jest.fn()];
 
-      emitter.on('event', callback);
+      emitter.on('event', callbacks[0]);
+      emitter.on('event2', callbacks[1]);
 
-      expect(emitter.callbacks.event).toContain(callback);
+      expect(emitter.callbacks.event).toContain(callbacks[0]);
+      expect(emitter.callbacks.event2).toContain(callbacks[1]);
 
-      emitter.off('event', callback);
+      emitter.off('event', callbacks[0]);
 
-      expect(emitter.callbacks.event).not.toContain(callback);
+      expect(emitter.callbacks.event).not.toContain(callbacks[0]);
+      expect(emitter.callbacks.event2).toContain(callbacks[1]);
     });
   });
 

--- a/src/Draggable/Emitter/tests/Emitter.test.js
+++ b/src/Draggable/Emitter/tests/Emitter.test.js
@@ -44,6 +44,18 @@ describe('Emitter', () => {
       expect(emitter.callbacks.event).not.toContain(callbacks[0]);
       expect(emitter.callbacks.event2).toContain(callbacks[1]);
     });
+
+    it('removes multiple callbacks of event type', () => {
+      const callback = jest.fn();
+
+      emitter.on('event', callback, callback);
+
+      expect(emitter.callbacks.event).toContain(callback);
+
+      emitter.off('event', callback);
+
+      expect(emitter.callbacks.event).not.toContain(callback);
+    });
   });
 
   describe('#trigger', () => {


### PR DESCRIPTION
### This PR implements or fixes...

`Emitter#off` fails to remove multiple event listeners of the same type. This PR also adds "`removes multiple callbacks of event type`" test case which demonstrates this issue.

The `Array.filter()` approach is slightly faster as well (at least on Chrome, but probably across the board as well):
```
splice – 100000 x 50 elements: 254.009765625ms
filter – 100000 x 50 elements: 53.3818359375ms
–––––––––––––––––––––
splice – 100000 x 100 elements: 502.173095703125ms
filter – 100000 x 100 elements: 72.447998046875ms
–––––––––––––––––––––
splice – 100000 x 150 elements: 707.951171875ms
filter – 100000 x 150 elements: 98.218994140625ms
```

### Does this PR require the Docs to be updated?

No

### Does this PR require new tests?

No
