### PR TITLE
fix(delay_distance): fix drag start concurrency

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,4 +1,7 @@
 {
+  "trailingComma": "all",
   "printWidth": 120,
-  "singleQuote": true
+  "singleQuote": true,
+  "bracketSpacing": false,
+  "arrowParens": "always"
 }

--- a/scripts/test/helpers/constants.js
+++ b/scripts/test/helpers/constants.js
@@ -11,6 +11,8 @@ export const defaultMouseEventOptions = {
   button: 0,
   clientX: 0,
   clientY: 0,
+  pageX: 0,
+  pageY: 0,
 };
 
-export const DRAG_DELAY = 0;
+export const DRAG_DELAY = 100;

--- a/scripts/test/helpers/sensor.js
+++ b/scripts/test/helpers/sensor.js
@@ -2,7 +2,12 @@ import {DRAG_DELAY, defaultTouchEventOptions, defaultMouseEventOptions} from './
 import {triggerEvent} from './event';
 
 export function waitForDragDelay(dragDelay = DRAG_DELAY) {
+  const next = Date.now() + dragDelay + 1;
+  const dateMock = jest.spyOn(Date, 'now').mockImplementation(() => {
+    return next;
+  });
   jest.runTimersToTime(dragDelay + 1);
+  dateMock.mockRestore();
 }
 
 export function clickMouse(element, options = {}) {

--- a/scripts/test/matchers/sensor.js
+++ b/scripts/test/matchers/sensor.js
@@ -1,7 +1,8 @@
-function toHaveTriggeredSensorEvent(received, expectedEventName) {
+function toHaveTriggeredSensorEvent(received, expectedEventName, count) {
   let triggered = false;
-
+  let callCount = 0;
   function callback() {
+    count !== undefined && (callCount = callCount + 1);
     triggered = true;
   }
 
@@ -9,14 +10,15 @@ function toHaveTriggeredSensorEvent(received, expectedEventName) {
   received();
   document.removeEventListener(expectedEventName, callback);
 
-  const pass = Boolean(triggered);
+  const pass = Boolean(triggered) && Boolean(count === undefined || callCount === count);
 
   return {
     pass,
     message: () => {
       const expectation = pass ? 'not to have been' : 'to have been';
+      const defaultMessage = `Expected sensor event '${expectedEventName}' ${expectation} to be triggered`;
 
-      return `Expected sensor event '${expectedEventName}' ${expectation} triggered`;
+      return count ? `${defaultMessage} ${count} time(s)` : defaultMessage;
     },
   };
 }

--- a/src/Draggable/Sensors/DragSensor/DragSensor.js
+++ b/src/Draggable/Sensors/DragSensor/DragSensor.js
@@ -161,7 +161,6 @@ export default class DragSensor extends Sensor {
     this.trigger(container, dragStopEvent);
 
     this.dragging = false;
-    this.delayOver = false;
     this.startEvent = null;
 
     this[reset]();
@@ -210,7 +209,6 @@ export default class DragSensor extends Sensor {
     this.startEvent = event;
 
     this.mouseDownTimeout = setTimeout(() => {
-      this.delayOver = true;
       target.draggable = true;
       this.draggableElement = target;
     }, this.options.delay);

--- a/src/Draggable/Sensors/MouseSensor/tests/MouseSensor.test.js
+++ b/src/Draggable/Sensors/MouseSensor/tests/MouseSensor.test.js
@@ -1,5 +1,4 @@
 import {createSandbox, triggerEvent, waitForDragDelay, DRAG_DELAY, clickMouse, moveMouse, releaseMouse} from 'helper';
-
 import MouseSensor from '..';
 
 const sampleMarkup = `
@@ -14,154 +13,281 @@ describe('MouseSensor', () => {
   let mouseSensor;
   let draggableElement;
 
-  beforeEach(() => {
+  function setup(options = {delay: 0, distance: 0}) {
     sandbox = createSandbox(sampleMarkup);
     const containers = sandbox.querySelectorAll('ul');
     draggableElement = sandbox.querySelector('li');
-    mouseSensor = new MouseSensor(containers, {delay: DRAG_DELAY});
+    mouseSensor = new MouseSensor(containers, options);
     mouseSensor.attach();
-  });
+  }
 
-  afterEach(() => {
+  function teardown() {
     mouseSensor.detach();
     sandbox.parentNode.removeChild(sandbox);
-  });
+  }
 
-  it('triggers `drag:start` sensor event on mousedown', () => {
-    function dragFlow() {
-      clickMouse(draggableElement);
-      waitForDragDelay();
-      releaseMouse(document.body);
-    }
+  describe('common', () => {
+    beforeEach(setup);
 
-    expect(dragFlow).toHaveTriggeredSensorEvent('drag:start');
-  });
+    afterEach(teardown);
 
-  it('cancels `drag:start` event when canceling sensor event', () => {
-    sandbox.addEventListener('drag:start', (event) => {
-      event.detail.cancel();
-    });
+    it('does not trigger `drag:start` event when clicking on non draggable element', () => {
+      function dragFlow() {
+        clickMouse(document.body);
+        waitForDragDelay();
+      }
 
-    function dragFlow() {
-      clickMouse(draggableElement);
-      waitForDragDelay();
-      releaseMouse(draggableElement);
-    }
-
-    expect(dragFlow).toHaveCanceledSensorEvent('drag:start');
-  });
-
-  it('does not trigger `drag:start` event releasing mouse before timeout', () => {
-    function dragFlow() {
-      clickMouse(draggableElement);
-      waitForDragDelay();
-      releaseMouse(document.body);
-    }
-
-    function hastyDragFlow() {
-      clickMouse(draggableElement);
-      releaseMouse(document.body);
-    }
-
-    expect(hastyDragFlow).not.toHaveTriggeredSensorEvent('drag:start');
-
-    expect(hastyDragFlow).not.toHaveTriggeredSensorEvent('drag:stop');
-
-    expect(dragFlow).toHaveTriggeredSensorEvent('drag:start');
-
-    expect(dragFlow).toHaveTriggeredSensorEvent('drag:stop');
-  });
-
-  it('triggers `drag:move` event while moving the mouse', () => {
-    function dragFlow() {
-      clickMouse(draggableElement);
-      waitForDragDelay();
-      moveMouse(document.body);
-      releaseMouse(document.body);
-    }
-
-    expect(dragFlow).toHaveTriggeredSensorEvent('drag:move');
-  });
-
-  it('triggers `drag:stop` event when releasing mouse', () => {
-    function dragFlow() {
-      clickMouse(draggableElement);
-      waitForDragDelay();
-      moveMouse(document.body);
-      releaseMouse(document.body);
-    }
-
-    expect(dragFlow).toHaveTriggeredSensorEvent('drag:stop');
-  });
-
-  it('does not trigger `drag:start` event when right clicking or holding ctrl or meta key', () => {
-    function dragFlowWithRightClick() {
-      clickMouse(draggableElement, {button: 2});
-      waitForDragDelay();
-      releaseMouse(document.body);
-    }
-
-    function dragFlowWithCtrlKey() {
-      clickMouse(draggableElement, {ctrlKey: true});
-      waitForDragDelay();
-      releaseMouse(document.body);
-    }
-
-    function dragFlowWithMetaKey() {
-      clickMouse(draggableElement, {metaKey: true});
-      waitForDragDelay();
-      releaseMouse(document.body);
-    }
-
-    [dragFlowWithRightClick, dragFlowWithCtrlKey, dragFlowWithMetaKey].forEach((dragFlow) => {
       expect(dragFlow).not.toHaveTriggeredSensorEvent('drag:start');
     });
-  });
 
-  it('does not trigger `drag:start` event when clicking on none draggable element', () => {
-    function dragFlow() {
-      clickMouse(document.body);
+    it('prevents context menu while dragging', () => {
+      let contextMenuEvent = triggerEvent(draggableElement, 'contextmenu');
+
+      expect(contextMenuEvent).not.toHaveDefaultPrevented();
+
+      clickMouse(draggableElement);
       waitForDragDelay();
-    }
+      contextMenuEvent = triggerEvent(draggableElement, 'contextmenu');
 
-    expect(dragFlow).not.toHaveTriggeredSensorEvent('drag:start');
+      expect(contextMenuEvent).toHaveDefaultPrevented();
+
+      releaseMouse(draggableElement);
+    });
+
+    it('prevents native drag when initiating drag flow', () => {
+      let dragEvent = triggerEvent(draggableElement, 'dragstart');
+
+      expect(dragEvent).not.toHaveDefaultPrevented();
+
+      clickMouse(draggableElement);
+      dragEvent = triggerEvent(draggableElement, 'dragstart');
+
+      expect(dragEvent).toHaveDefaultPrevented();
+
+      releaseMouse(document.body);
+    });
+
+    it('does not prevent `dragstart` event when attempting to drag outside of draggable container', () => {
+      clickMouse(document.body);
+      moveMouse(document, {pageX: 1, pageY: 1});
+      const nativeDragEvent = triggerEvent(draggableElement, 'dragstart');
+
+      expect(nativeDragEvent).not.toHaveDefaultPrevented();
+
+      releaseMouse(document.body);
+    });
+
+    it('triggers `drag:stop` event when releasing mouse while dragging', () => {
+      function dragFlow() {
+        clickMouse(draggableElement);
+        waitForDragDelay();
+        releaseMouse(document.body);
+      }
+
+      expect(dragFlow).toHaveTriggeredSensorEvent('drag:stop');
+    });
+
+    it('does not trigger `drag:start` event when right clicking or holding ctrl or meta key', () => {
+      function dragFlowWithRightClick() {
+        clickMouse(draggableElement, {button: 2});
+        waitForDragDelay();
+        releaseMouse(document.body);
+      }
+
+      function dragFlowWithCtrlKey() {
+        clickMouse(draggableElement, {ctrlKey: true});
+        waitForDragDelay();
+        releaseMouse(document.body);
+      }
+
+      function dragFlowWithMetaKey() {
+        clickMouse(draggableElement, {metaKey: true});
+        waitForDragDelay();
+        releaseMouse(document.body);
+      }
+
+      [dragFlowWithRightClick, dragFlowWithCtrlKey, dragFlowWithMetaKey].forEach((dragFlow) => {
+        expect(dragFlow).not.toHaveTriggeredSensorEvent('drag:start');
+      });
+    });
+
+    it('cancels `drag:start` event when canceling sensor event', () => {
+      sandbox.addEventListener('drag:start', (event) => {
+        event.detail.cancel();
+      });
+
+      function dragFlow() {
+        clickMouse(draggableElement);
+        waitForDragDelay();
+        releaseMouse(draggableElement);
+      }
+
+      expect(dragFlow).toHaveCanceledSensorEvent('drag:start');
+    });
   });
 
-  it('prevents context menu while dragging', () => {
-    let contextMenuEvent = triggerEvent(draggableElement, 'contextmenu');
+  describe('using distance', () => {
+    beforeEach(() => {
+      setup({delay: 0, distance: 1});
+    });
 
-    expect(contextMenuEvent).not.toHaveDefaultPrevented();
+    afterEach(teardown);
 
-    clickMouse(draggableElement);
-    waitForDragDelay();
-    contextMenuEvent = triggerEvent(draggableElement, 'contextmenu');
+    it('triggers `drag:start` sensor event on mousemove after distance has been met', () => {
+      function dragFlow() {
+        clickMouse(draggableElement);
+        moveMouse(draggableElement, {pageY: 1, pageX: 0});
+        releaseMouse(document.body);
+      }
 
-    expect(contextMenuEvent).toHaveDefaultPrevented();
+      expect(dragFlow).toHaveTriggeredSensorEvent('drag:start');
+    });
 
-    releaseMouse(draggableElement);
+    it('does not trigger `drag:start` event releasing mouse before distance has been met', () => {
+      function dragFlow() {
+        clickMouse(draggableElement);
+        moveMouse(draggableElement, {pageY: 1, pageX: 0});
+        releaseMouse(document.body);
+      }
+
+      function hastyDragFlow() {
+        clickMouse(draggableElement);
+        releaseMouse(document.body);
+      }
+
+      expect(hastyDragFlow).not.toHaveTriggeredSensorEvent('drag:start');
+
+      expect(hastyDragFlow).not.toHaveTriggeredSensorEvent('drag:stop');
+
+      expect(dragFlow).toHaveTriggeredSensorEvent('drag:start');
+
+      expect(dragFlow).toHaveTriggeredSensorEvent('drag:stop');
+    });
+
+    it('triggers `drag:move` event while moving the mouse after distance has been met', () => {
+      function dragFlow() {
+        clickMouse(draggableElement);
+        moveMouse(draggableElement, {pageY: 1, pageX: 0});
+        moveMouse(document.body);
+        releaseMouse(document.body);
+      }
+
+      expect(dragFlow).toHaveTriggeredSensorEvent('drag:move');
+    });
   });
 
-  it('prevents native drag when initiating drag flow', () => {
-    let dragEvent = triggerEvent(draggableElement, 'dragstart');
+  describe('using delay', () => {
+    beforeEach(() => {
+      setup({delay: DRAG_DELAY, distance: 0});
+    });
 
-    expect(dragEvent).not.toHaveDefaultPrevented();
+    afterEach(teardown);
 
-    clickMouse(draggableElement);
-    waitForDragDelay();
-    dragEvent = triggerEvent(draggableElement, 'dragstart');
+    it('triggers `drag:start` sensor event after delay', () => {
+      function dragFlow() {
+        clickMouse(draggableElement);
+        waitForDragDelay();
+        releaseMouse(document.body);
+      }
 
-    expect(dragEvent).toHaveDefaultPrevented();
+      expect(dragFlow).toHaveTriggeredSensorEvent('drag:start');
+    });
 
-    releaseMouse(document.body);
+    it('does not trigger `drag:start` event releasing mouse before delay', () => {
+      function dragFlow() {
+        clickMouse(draggableElement);
+        waitForDragDelay();
+        releaseMouse(document.body);
+      }
+
+      function hastyDragFlow() {
+        clickMouse(draggableElement);
+        releaseMouse(document.body);
+      }
+
+      expect(hastyDragFlow).not.toHaveTriggeredSensorEvent('drag:start');
+
+      expect(hastyDragFlow).not.toHaveTriggeredSensorEvent('drag:stop');
+
+      expect(dragFlow).toHaveTriggeredSensorEvent('drag:start');
+
+      expect(dragFlow).toHaveTriggeredSensorEvent('drag:stop');
+    });
+
+    it('triggers `drag:move` event while moving the mouse after delay', () => {
+      function dragFlow() {
+        clickMouse(draggableElement);
+        waitForDragDelay();
+        moveMouse(document.body);
+        releaseMouse(document.body);
+      }
+
+      expect(dragFlow).toHaveTriggeredSensorEvent('drag:move');
+    });
   });
 
-  it('does not prevent `dragstart` event when attempting to drag outside of draggable container', () => {
-    clickMouse(document.body);
-    waitForDragDelay();
-    const nativeDragEvent = triggerEvent(draggableElement, 'dragstart');
+  describe('delay and distance', () => {
+    beforeEach(() => {
+      setup({delay: DRAG_DELAY, distance: 1});
+    });
 
-    expect(nativeDragEvent).not.toHaveDefaultPrevented();
+    afterEach(teardown);
 
-    releaseMouse(document.body);
+    it('does not trigger `drag:start` before delay ends', () => {
+      function dragFlow() {
+        clickMouse(draggableElement);
+        moveMouse(draggableElement, {pageY: 1, pageX: 0});
+        releaseMouse(document.body);
+      }
+      expect(dragFlow).not.toHaveTriggeredSensorEvent('drag:start');
+    });
+
+    it('does not trigger `drag:start` before distance is met', () => {
+      function dragFlow() {
+        clickMouse(draggableElement);
+        waitForDragDelay();
+        releaseMouse(document.body);
+      }
+      expect(dragFlow).not.toHaveTriggeredSensorEvent('drag:start');
+    });
+
+    it('only triggers `drag:start` sensor event once when delay ends after distance is met', () => {
+      function dragFlow() {
+        clickMouse(draggableElement);
+        moveMouse(draggableElement, {pageY: 1, pageX: 0});
+        waitForDragDelay();
+        releaseMouse(document.body);
+      }
+      expect(dragFlow).toHaveTriggeredSensorEvent('drag:start', 1);
+    });
+
+    it('only triggers `drag:start` sensor event once when distance and delay are met at the same time', () => {
+      function dragFlow() {
+        clickMouse(draggableElement);
+        const next = Date.now() + DRAG_DELAY;
+        const dateMock = jest.spyOn(Date, 'now').mockImplementation(() => {
+          return next;
+        });
+        moveMouse(draggableElement, {pageY: 1, pageX: 0});
+        jest.runTimersToTime(DRAG_DELAY);
+        releaseMouse(document.body);
+        dateMock.mockRestore();
+      }
+      expect(dragFlow).toHaveTriggeredSensorEvent('drag:start', 1);
+    });
+    it('only triggers `drag:start` sensor event once when distance is met after delay', () => {
+      function dragFlow() {
+        clickMouse(draggableElement);
+        const next = Date.now() + DRAG_DELAY + 1;
+        const dateMock = jest.spyOn(Date, 'now').mockImplementation(() => {
+          return next;
+        });
+        jest.runTimersToTime(DRAG_DELAY + 1);
+        moveMouse(draggableElement, {pageY: 1, pageX: 0});
+        releaseMouse(document.body);
+        dateMock.mockRestore();
+      }
+      expect(dragFlow).toHaveTriggeredSensorEvent('drag:start', 1);
+    });
   });
 });

--- a/src/Draggable/Sensors/Sensor/Sensor.js
+++ b/src/Draggable/Sensors/Sensor/Sensor.js
@@ -40,20 +40,6 @@ export default class Sensor {
     this.currentContainer = null;
 
     /**
-     * The distance moved from the first pointer down location, no longer updated after the drag has started
-     * @property distance
-     * @type {Number}
-     */
-    this.distance = 0;
-
-    /**
-     * Indicates whether the delay has ended
-     * @property delayOver
-     * @type {Boolean}
-     */
-    this.delayOver = false;
-
-    /**
      * The event of the initial sensor down
      * @property startEvent
      * @type {Event}

--- a/src/Draggable/Sensors/TouchSensor/TouchSensor.js
+++ b/src/Draggable/Sensors/TouchSensor/TouchSensor.js
@@ -1,4 +1,4 @@
-import {closest, distance} from 'shared/utils';
+import {closest, distance as euclideanDistance, touchCoords} from 'shared/utils';
 import Sensor from '../Sensor';
 import {DragStartSensorEvent, DragMoveSensorEvent, DragStopSensorEvent} from '../SensorEvent';
 
@@ -52,7 +52,7 @@ export default class TouchSensor extends Sensor {
     this.currentScrollableParent = null;
 
     /**
-     * TimeoutID for long touch
+     * TimeoutID for managing delay
      * @property tapTimeout
      * @type {Number}
      */
@@ -97,27 +97,26 @@ export default class TouchSensor extends Sensor {
     if (!container) {
       return;
     }
+    const {distance = 0, delay = 0} = this.options;
+    const {pageX, pageY} = touchCoords(event);
 
+    Object.assign(this, {pageX, pageY});
+    this.onTouchStartAt = Date.now();
     this.startEvent = event;
+    this.currentContainer = container;
 
-    document.addEventListener('touchmove', this[onTouchMove]);
     document.addEventListener('touchend', this[onTouchEnd]);
     document.addEventListener('touchcancel', this[onTouchEnd]);
     document.addEventListener('touchmove', this[onDistanceChange]);
     container.addEventListener('contextmenu', onContextMenu);
 
-    if (this.options.distance) {
+    if (distance) {
       preventScrolling = true;
     }
 
-    this.currentContainer = container;
-    this.tapTimeout = setTimeout(() => {
-      this.delayOver = true;
-      if (this.touchMoved || this.distance < this.options.distance) {
-        return;
-      }
-      this[startDrag]();
-    }, this.options.delay);
+    this.tapTimeout = window.setTimeout(() => {
+      this[onDistanceChange]({touches: [{pageX: this.pageX, pageY: this.pageY}]});
+    }, delay);
   }
 
   /**
@@ -127,7 +126,7 @@ export default class TouchSensor extends Sensor {
   [startDrag]() {
     const startEvent = this.startEvent;
     const container = this.currentContainer;
-    const touch = startEvent.touches[0] || startEvent.changedTouches[0];
+    const touch = touchCoords(startEvent);
 
     const dragStartEvent = new DragStartSensorEvent({
       clientX: touch.pageX,
@@ -140,47 +139,49 @@ export default class TouchSensor extends Sensor {
     this.trigger(this.currentContainer, dragStartEvent);
 
     this.dragging = !dragStartEvent.canceled();
+
+    if (this.dragging) {
+      document.addEventListener('touchmove', this[onTouchMove]);
+    }
     preventScrolling = this.dragging;
   }
 
   /**
-   * Detect change in distance
+   * Touch move handler prior to drag start.
    * @private
    * @param {Event} event - Touch move event
    */
   [onDistanceChange](event) {
-    if (this.dragging || !this.options.distance) {
-      return;
-    }
+    const {delay, distance} = this.options;
+    const {startEvent} = this;
+    const start = touchCoords(startEvent);
+    const current = touchCoords(event);
+    const timeElapsed = Date.now() - this.onTouchStartAt;
+    const distanceTravelled = euclideanDistance(start.pageX, start.pageY, current.pageX, current.pageY);
 
-    const tap = this.startEvent.touches[0] || this.startEvent.changedTouches[0];
-    const touch = event.touches[0] || event.changedTouches[0];
-
-    this.distance = distance(tap.pageX, tap.pageY, touch.pageX, touch.pageY);
-
-    if (this.delayOver && this.distance >= this.options.distance) {
+    Object.assign(this, current);
+    if (timeElapsed >= delay && distanceTravelled >= distance) {
+      window.clearTimeout(this.tapTimeout);
+      document.removeEventListener('touchmove', this[onDistanceChange]);
       this[startDrag]();
     }
   }
 
   /**
-   * Touch move handler
+   * Mouse move handler while dragging
    * @private
    * @param {Event} event - Touch move event
    */
   [onTouchMove](event) {
-    this.touchMoved = true;
-
     if (!this.dragging) {
       return;
     }
-
-    const touch = event.touches[0] || event.changedTouches[0];
-    const target = document.elementFromPoint(touch.pageX - window.scrollX, touch.pageY - window.scrollY);
+    const {pageX, pageY} = touchCoords(event);
+    const target = document.elementFromPoint(pageX - window.scrollX, pageY - window.scrollY);
 
     const dragMoveEvent = new DragMoveSensorEvent({
-      clientX: touch.pageX,
-      clientY: touch.pageY,
+      clientX: pageX,
+      clientY: pageY,
       target,
       container: this.currentContainer,
       originalEvent: event,
@@ -195,32 +196,31 @@ export default class TouchSensor extends Sensor {
    * @param {Event} event - Touch end event
    */
   [onTouchEnd](event) {
-    this.touchMoved = false;
+    clearTimeout(this.tapTimeout);
     preventScrolling = false;
 
     document.removeEventListener('touchend', this[onTouchEnd]);
     document.removeEventListener('touchcancel', this[onTouchEnd]);
-    document.removeEventListener('touchmove', this[onTouchMove]);
     document.removeEventListener('touchmove', this[onDistanceChange]);
 
     if (this.currentContainer) {
       this.currentContainer.removeEventListener('contextmenu', onContextMenu);
     }
 
-    clearTimeout(this.tapTimeout);
-
     if (!this.dragging) {
       return;
     }
 
-    const touch = event.touches[0] || event.changedTouches[0];
-    const target = document.elementFromPoint(touch.pageX - window.scrollX, touch.pageY - window.scrollY);
+    document.removeEventListener('touchmove', this[onTouchMove]);
+
+    const {pageX, pageY} = touchCoords(event);
+    const target = document.elementFromPoint(pageX - window.scrollX, pageY - window.scrollY);
 
     event.preventDefault();
 
     const dragStopEvent = new DragStopSensorEvent({
-      clientX: touch.pageX,
-      clientY: touch.pageY,
+      clientX: pageX,
+      clientY: pageY,
       target,
       container: this.currentContainer,
       originalEvent: event,
@@ -230,8 +230,6 @@ export default class TouchSensor extends Sensor {
 
     this.currentContainer = null;
     this.dragging = false;
-    this.distance = 0;
-    this.delayOver = false;
     this.startEvent = null;
   }
 }

--- a/src/Draggable/tests/Draggable.test.js
+++ b/src/Draggable/tests/Draggable.test.js
@@ -294,12 +294,11 @@ describe('Draggable', () => {
         draggable: 'li',
       });
       const draggableElement = sandbox.querySelector('li');
-      document.elementFromPoint = () => draggableElement;
 
       triggerEvent(draggableElement, 'mousedown', {button: 0});
 
       // Wait for delay
-      jest.runTimersToTime(100);
+      waitForDragDelay(100);
 
       const containerChildren = newInstance.getDraggableElementsForContainer(draggableElement.parentNode);
 
@@ -336,7 +335,6 @@ describe('Draggable', () => {
       clickMouse(draggableElement);
       waitForDragDelay(100);
       moveMouse(dynamicContainer);
-
       expect(dragOverContainerHandler).toHaveBeenCalled();
 
       releaseMouse(newInstance.source);
@@ -432,7 +430,7 @@ describe('Draggable', () => {
     const draggableElement = document.querySelector('li');
 
     clickMouse(draggableElement);
-    waitForDragDelay(100);
+    waitForDragDelay();
     waitForRequestAnimationFrame();
 
     expect(dragStartHandler).toHaveBeenCalledTimes(1);
@@ -456,9 +454,8 @@ describe('Draggable', () => {
     newInstance.on('drag:start', callback);
 
     triggerEvent(draggableElement, 'mousedown', {button: 0});
-
     // Wait for delay
-    jest.runTimersToTime(100);
+    waitForDragDelay(100);
 
     const call = callback.mock.calls[0][0];
 
@@ -482,7 +479,7 @@ describe('Draggable', () => {
     triggerEvent(draggableElement, 'mousedown', {button: 0});
 
     // Wait for delay
-    jest.runTimersToTime(100);
+    waitForDragDelay(100);
 
     triggerEvent(draggableElement, 'dragstart', {button: 0});
 
@@ -515,7 +512,7 @@ describe('Draggable', () => {
     triggerEvent(draggableElement, 'mousedown', {button: 0});
 
     // Wait for delay
-    jest.runTimersToTime(100);
+    waitForDragDelay(100);
 
     triggerEvent(draggableElement, 'dragstart', {button: 0});
 
@@ -534,7 +531,7 @@ describe('Draggable', () => {
     triggerEvent(draggableElement, 'mousedown', {button: 0});
 
     // Wait for delay
-    jest.runTimersToTime(100);
+    waitForDragDelay(100);
 
     const callback = jest.fn();
     newInstance.on('drag:move', callback);
@@ -568,7 +565,7 @@ describe('Draggable', () => {
     triggerEvent(draggableElement, 'mousedown', {button: 0});
 
     // Wait for delay
-    jest.runTimersToTime(100);
+    waitForDragDelay(100);
 
     const callback = jest.fn();
     newInstance.on('drag:stop', callback);
@@ -592,7 +589,7 @@ describe('Draggable', () => {
     triggerEvent(draggableElement, 'mousedown', {button: 0});
 
     // Wait for delay
-    jest.runTimersToTime(100);
+    waitForDragDelay(100);
 
     expect(newInstance.source.classList).toContain('draggable-source--is-dragging');
 
@@ -609,7 +606,7 @@ describe('Draggable', () => {
     triggerEvent(draggableElement, 'mousedown', {button: 0});
 
     // Wait for delay
-    jest.runTimersToTime(100);
+    waitForDragDelay(100);
 
     const source = newInstance.source;
 
@@ -634,7 +631,7 @@ describe('Draggable', () => {
     triggerEvent(draggableElement, 'mousedown', {button: 0});
 
     // Wait for delay
-    jest.runTimersToTime(100);
+    waitForDragDelay(100);
 
     const source = newInstance.source;
 
@@ -654,7 +651,7 @@ describe('Draggable', () => {
     triggerEvent(draggableElement, 'mousedown', {button: 0});
 
     // Wait for delay
-    jest.runTimersToTime(100);
+    waitForDragDelay(100);
 
     expect(document.body.classList).toContain('draggable--is-dragging');
 
@@ -672,8 +669,7 @@ describe('Draggable', () => {
     triggerEvent(draggableElement, 'mousedown', {button: 0});
 
     // Wait for delay
-    jest.runTimersToTime(100);
-
+    waitForDragDelay(100);
     expect(document.body.classList).toContain('draggable--is-dragging');
 
     triggerEvent(document.body, 'mouseup', {button: 0});
@@ -695,7 +691,7 @@ describe('Draggable', () => {
     triggerEvent(draggableElement, 'mousedown', {button: 0});
 
     // Wait for delay
-    jest.runTimersToTime(100);
+    waitForDragDelay(100);
 
     expect(document.body.classList).not.toContain('draggable--is-dragging');
 
@@ -713,7 +709,7 @@ describe('Draggable', () => {
     triggerEvent(draggableElement, 'mousedown', {button: 0});
 
     // Wait for delay
-    jest.runTimersToTime(100);
+    waitForDragDelay(100);
 
     triggerEvent(draggableElement, 'mouseup', {button: 0});
 
@@ -731,7 +727,7 @@ describe('Draggable', () => {
     triggerEvent(draggableElement, 'mousedown', {button: 0});
 
     // Wait for delay
-    jest.runTimersToTime(100);
+    waitForDragDelay(100);
 
     triggerEvent(document.body, 'mouseup', {button: 0});
 
@@ -754,7 +750,7 @@ describe('Draggable', () => {
     triggerEvent(draggableElement, 'mousedown', {button: 0});
 
     // Wait for delay
-    jest.runTimersToTime(100);
+    waitForDragDelay(100);
 
     expect(containers[0].classList).toContain('draggable-container--is-dragging');
 
@@ -772,7 +768,7 @@ describe('Draggable', () => {
     triggerEvent(draggableElement, 'mousedown', {button: 0});
 
     // Wait for delay
-    jest.runTimersToTime(100);
+    waitForDragDelay(100);
 
     expect(containers[0].classList).toContain('draggable-container--is-dragging');
 
@@ -794,7 +790,7 @@ describe('Draggable', () => {
     triggerEvent(draggableElement, 'mousedown', {button: 0});
 
     // Wait for delay
-    jest.runTimersToTime(100);
+    waitForDragDelay(100);
 
     expect(containers[0].classList).not.toContain('draggable-container--is-dragging');
 
@@ -811,7 +807,7 @@ describe('Draggable', () => {
     triggerEvent(draggableElement, 'mousedown', {button: 0});
 
     // Wait for delay
-    jest.runTimersToTime(100);
+    waitForDragDelay(100);
 
     expect(draggableElement.classList.contains(newInstance.getClassNameFor('source:original'))).toBeTruthy();
 
@@ -839,7 +835,7 @@ describe('Draggable', () => {
     triggerEvent(draggableElement, 'mousedown', {button: 0});
 
     // Wait for delay
-    jest.runTimersToTime(100);
+    waitForDragDelay(100);
 
     expect(newInstance.isDragging()).toBe(true);
 
@@ -847,13 +843,13 @@ describe('Draggable', () => {
     triggerEvent(draggableElement.nextElementSibling, 'mousemove', {button: 0});
 
     // Wait for delay
-    jest.runTimersToTime(100);
+    waitForDragDelay(100);
 
     document.elementFromPoint = () => document.body;
     triggerEvent(document.body, 'mousemove', {button: 0});
 
     // Wait for delay
-    jest.runTimersToTime(100);
+    waitForDragDelay(100);
 
     triggerEvent(document.body, 'mouseup', {button: 0});
   });

--- a/src/shared/utils/index.js
+++ b/src/shared/utils/index.js
@@ -1,3 +1,4 @@
 export {default as closest} from './closest';
 export {default as requestNextAnimationFrame} from './requestNextAnimationFrame';
 export {default as distance} from './distance';
+export {default as touchCoords} from './touchCoords';

--- a/src/shared/utils/touchCoords/index.js
+++ b/src/shared/utils/touchCoords/index.js
@@ -1,0 +1,3 @@
+import touchCoords from './touchCoords';
+
+export default touchCoords;

--- a/src/shared/utils/touchCoords/touchCoords.js
+++ b/src/shared/utils/touchCoords/touchCoords.js
@@ -1,0 +1,9 @@
+/**
+ * Returns the first touch event found in touches or changedTouches of a touch events.
+ * @param {TouchEvent} event a touch event
+ * @return {Touch} a touch object
+ */
+export default function touchCoords(event = {}) {
+  const {touches, changedTouches} = event;
+  return (touches && touches[0]) || (changedTouches && changedTouches[0]);
+}


### PR DESCRIPTION
### This PR fixes #366 

The original implementation allowed multiple concurrent entry points via timeout and mouse move to enter startDrag based on a pair of flags for determining if the delay and/or distance requirements were met. The flag for determining if the delay was met was not correctly reset on mouse up prior to dragging, nor on drag cancel. Instead of chasing flags around I've altered the implementation to only allow a single entry point into startDrag which is responsible for ensuring that all delay/distance requirements are met as well as cleaning up the delay timeout and mouse move handlers prior to calling startDrag.

There is also an update to the prettier config to match the eslint rules for trailing comma, bracket spacing and arrow parens.

### This PR closes the following issues
#366 

### Does this PR require the Docs to be updated?

Yes

### Does this PR require new tests?

Yes - tests have been added for both distance and distance + delay configurations.

### This branch been tested on

**Browsers:**

* [x] Chrome 78.0.3904.87 (Official Build) (64-bit)
* [x] Firefox 70.0.1 (64-bit) (osx)
* [x] Safari 13.0.3 (14608.3.10.10.1)
* [ ] IE / Edge _version_
* [x] iOS Browser 13.2.3
* [ ] Android Browser _version_
