### PR TITLE
use sensorEvent to detect touch support

### DIFF
--- a/src/Draggable/Plugins/Scrollable/Scrollable.js
+++ b/src/Draggable/Plugins/Scrollable/Scrollable.js
@@ -162,7 +162,7 @@ export default class Scrollable extends AbstractPlugin {
     const sensorEvent = dragEvent.sensorEvent;
     const scrollOffset = {x: 0, y: 0};
 
-    if ('ontouchstart' in window) {
+    if (sensorEvent.originalEvent instanceof TouchEvent) {
       scrollOffset.y = window.pageYOffset || document.documentElement.scrollTop || document.body.scrollTop || 0;
       scrollOffset.x = window.pageXOffset || document.documentElement.scrollLeft || document.body.scrollLeft || 0;
     }


### PR DESCRIPTION
### This PR implements or fixes...
this PR ensures that the triggered event is used to detect a touch device scenario as only checking if the device itself supports touch gives inconsistent results.

### This PR closes the following issues...
#244 


### Does this PR require the Docs to be updated?

No

### Does this PR require new tests?

No

### This branch been tested on...

**Browsers:**

* [x] Chrome _version_
* [x] Firefox _version_
* [ ] Safari _version_
* [x] IE / Edge _version_
* [ ] iOS Browser _version_
* [x] Android Browser _version_
