### PR TITLE
Added `distance?: number` to DraggableOptions interface

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -100,6 +100,7 @@ declare module '@shopify/draggable' {
 
     interface DraggableOptions {
         draggable?: string;
+        distance?: number;
         handle?: string | NodeList | HTMLElement[] | HTMLElement | ((currentElement: HTMLElement) => HTMLElement);
         delay?: number;
         plugins?: Array<typeof AbstractPlugin>;


### PR DESCRIPTION
The `DraggableOptions` interface is missing the `distance` option.