### PR TITLE
add checks before applying any styling

### DIFF
--- a/src/Plugins/SwapAnimation/SwapAnimation.js
+++ b/src/Plugins/SwapAnimation/SwapAnimation.js
@@ -108,24 +108,30 @@ export default class SwapAnimation extends AbstractPlugin {
  */
 function animate(from, to, {duration, easingFunction, horizontal}) {
   for (const element of [from, to]) {
-    element.style.pointerEvents = 'none';
+    if (element && element.style) {
+      element.style.pointerEvents = 'none';
+    }  
   }
 
-  if (horizontal) {
-    const width = from.offsetWidth;
-    from.style.transform = `translate3d(${width}px, 0, 0)`;
-    to.style.transform = `translate3d(-${width}px, 0, 0)`;
-  } else {
-    const height = from.offsetHeight;
-    from.style.transform = `translate3d(0, ${height}px, 0)`;
-    to.style.transform = `translate3d(0, -${height}px, 0)`;
+  if (from && to && from.style && to.style) {
+    if (horizontal) {
+      const width = from.offsetWidth;
+      from.style.transform = `translate3d(${width}px, 0, 0)`;
+      to.style.transform = `translate3d(-${width}px, 0, 0)`;
+    } else {
+      const height = from.offsetHeight;
+      from.style.transform = `translate3d(0, ${height}px, 0)`;
+      to.style.transform = `translate3d(0, -${height}px, 0)`;
+    }
   }
-
+  
   requestAnimationFrame(() => {
     for (const element of [from, to]) {
-      element.addEventListener('transitionend', resetElementOnTransitionEnd);
-      element.style.transition = `transform ${duration}ms ${easingFunction}`;
-      element.style.transform = '';
+      if (element && element.style && element.addEventListener) {
+        element.addEventListener('transitionend', resetElementOnTransitionEnd);
+        element.style.transition = `transform ${duration}ms ${easingFunction}`;
+        element.style.transform = '';
+      }  
     }
   });
 }


### PR DESCRIPTION



### This PR implements or fixes... _(explain your changes)_
adds checks before applying any transition styles to element this fixes the issue when an element is dragged to another drop zone SwapAnimation Plugin throws `Cannot read property 'style' of undefined`
…

### This PR closes the following issues... _(if applicable)_
Fixes #261
…

### Does this PR require the Docs to be updated?
no
…

### Does this PR require new tests?
no
…

### This branch been tested on... _(click all that apply / add new items)_

**Browsers:**

* [x] Chrome _version_
* [x] Firefox _version_
* [ ] Safari _version_
* [x] IE / Edge _version_
* [ ] iOS Browser _version_
* [ ] Android Browser _version_
