### PR TITLE
fix(resize mirror plugin) : dont appends mirror when mirror was removed

### DIFF
--- a/src/Plugins/ResizeMirror/ResizeMirror.js
+++ b/src/Plugins/ResizeMirror/ResizeMirror.js
@@ -126,6 +126,10 @@ export default class ResizeMirror extends AbstractPlugin {
    */
   [resize]({overContainer, over}) {
     requestAnimationFrame(() => {
+      if (!this.mirror.parentNode) {
+        return;
+      }
+
       if (this.mirror.parentNode !== overContainer) {
         overContainer.appendChild(this.mirror);
       }

--- a/src/Plugins/ResizeMirror/tests/ResizeMirror.test.js
+++ b/src/Plugins/ResizeMirror/tests/ResizeMirror.test.js
@@ -7,6 +7,7 @@ import {
   waitForDragDelay,
   waitForPromisesToResolve,
   DRAG_DELAY,
+  drag,
 } from 'helper';
 import {Draggable} from '../../..';
 import ResizeMirror from '..';
@@ -128,6 +129,18 @@ describe('ResizeMirror', () => {
     expect(mockedAppendChild).not.toHaveBeenCalled();
 
     releaseMouse(largerDraggable);
+  });
+
+  it('dont appends mirror when mirror was removed', async () => {
+    drag({from: smallerDraggable, to: smallerDraggable});
+    drag({from: smallerDraggable, to: smallerDraggable});
+
+    await waitForPromisesToResolve();
+    waitForRequestAnimationFrame();
+
+    const mirror = document.querySelector('.draggable-mirror');
+
+    expect(mirror).toBeNull();
   });
 });
 


### PR DESCRIPTION
Mirror may append after it removed when high frequency dragging.

### This PR implements or fixes... _(explain your changes)_

Cancel appends mirror when mirror was removed.

### This PR closes the following issues... _(if applicable)_

No

### Does this PR require the Docs to be updated?

No

### Does this PR require new tests?

Yes

### This branch been tested on... _(click all that apply / add new items)_

**Browsers:**

* [x] Chrome 77.0.3865.120
* [x] Firefox 76.0.1
* [ ] Safari _version_
* [x] IE / Edge 83.0.478.45
* [ ] iOS Browser _version_
* [ ] Android Browser _version_
