### PR TITLE
Add SortAnimation plugin and example

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,6 +126,7 @@ You can find the documentation for each module within their respective directori
   - [ResizeMirror](src/Plugins/ResizeMirror)
   - [Snappable](src/Plugins/Snappable)
   - [SwapAnimation](src/Plugins/SwapAnimation)
+  - [SortAnimation](src/Plugins/SortAnimation)
 - [Sortable](src/Sortable)
   - [SortableEvent](src/Sortable/SortableEvent)
 - [Swappable](src/Swappable)

--- a/examples/src/content/Plugins/SortAnimation/SortAnimation.html
+++ b/examples/src/content/Plugins/SortAnimation/SortAnimation.html
@@ -1,0 +1,17 @@
+{% import 'components/Block/Block.html' as Block %}
+
+{% macro render(id) %}
+  <section id="{{ id }}" class="{{ id }}">
+    <article class="BlockLayout BlockLayout--typeFlex">
+      {{ Block.render('one',   {index: 1, draggable: true}) }}
+      {{ Block.render('two',   {index: 2, draggable: true}) }}
+      {{ Block.render('three', {index: 3, draggable: true}) }}
+      {{ Block.render('four',  {index: 4, draggable: true}) }}
+      {{ Block.render('five',  {index: 5, draggable: true}) }}
+      {{ Block.render('six',   {index: 6, draggable: true}) }}
+      {{ Block.render('seven', {index: 7, draggable: true}) }}
+      {{ Block.render('eight', {index: 8, draggable: true}) }}
+      {{ Block.render('nine',  {index: 9, draggable: true}) }}
+    </article>
+  </section>
+{% endmacro %}

--- a/examples/src/content/Plugins/SortAnimation/SortAnimation.scss
+++ b/examples/src/content/Plugins/SortAnimation/SortAnimation.scss
@@ -1,0 +1,39 @@
+////
+/// Content
+/// SortAnimation
+////
+
+@import 'utils/shared/functions';
+@import 'utils/shared/layout';
+
+$sort-anim-block-name: unquote('Block');
+
+.SortAnimation {
+  @include draggable-source-layout($sort-anim-block-name, 1, 2, 4, 5, 7, 8) {
+    flex-basis: 50%;
+  }
+
+  @include draggable-source-layout($sort-anim-block-name, 3, 6, 9) {
+    flex-basis: 100%;
+  }
+
+  @media screen and (min-width: get-breakpoint(tablet)) {
+    @include draggable-source-layout($sort-anim-block-name, 1, 2, 3, 4, 5, 6, 7, 8, 9) {
+      flex-basis: 33.333%;
+    }
+  }
+
+  .BlockContent {
+    @media screen and (min-width: get-breakpoint(tablet)) {
+      height: rows(3);
+    }
+
+    @media screen and (min-width: get-breakpoint(desktop)) {
+      height: rows(4);
+    }
+
+    @media screen and (min-width: get-breakpoint('1080p', wide)) {
+      height: rows(5);
+    }
+  }
+}

--- a/examples/src/content/Plugins/SortAnimation/index.js
+++ b/examples/src/content/Plugins/SortAnimation/index.js
@@ -1,0 +1,24 @@
+// eslint-disable-next-line import/no-unresolved
+import {Sortable, Plugins} from '@shopify/draggable';
+
+export default function SortAnimation() {
+  const containers = document.querySelectorAll('#SortAnimation .BlockLayout');
+
+  if (containers.length === 0) {
+    return false;
+  }
+
+  const sortable = new Sortable(containers, {
+    draggable: '.Block--isDraggable',
+    mirror: {
+      constrainDimensions: true,
+    },
+    plugins: [Plugins.SortAnimation],
+    swapAnimation: {
+      duration: 200,
+      easingFunction: 'ease-in-out',
+    },
+  });
+
+  return sortable;
+}

--- a/examples/src/content/index.js
+++ b/examples/src/content/index.js
@@ -16,6 +16,7 @@ import GridLayout from './Swappable/GridLayout';
 import PluginsCollidable from './Plugins/Collidable';
 import PluginsSnappable from './Plugins/Snappable';
 import PluginsSwapAnimation from './Plugins/SwapAnimation';
+import PluginsSortAnimation from './Plugins/SortAnimation';
 
 const Content = {
   Home,
@@ -30,6 +31,7 @@ const Content = {
   PluginsCollidable,
   PluginsSnappable,
   PluginsSwapAnimation,
+  PluginsSortAnimation,
 };
 
 export default Content;

--- a/examples/src/styles/examples-app.scss
+++ b/examples/src/styles/examples-app.scss
@@ -58,3 +58,4 @@
 @import 'content/Plugins/Collidable/Collidable';
 @import 'content/Plugins/Snappable/Snappable';
 @import 'content/Plugins/SwapAnimation/SwapAnimation';
+@import 'content/Plugins/SortAnimation/SortAnimation';

--- a/examples/src/views/data-pages.json
+++ b/examples/src/views/data-pages.json
@@ -31,7 +31,8 @@
       "Plugins": [
         "Collidable",
         "Snappable",
-        "~Swap Animation"
+        "~Swap Animation",
+        "Sort Animation"
       ]
     }
   ]

--- a/examples/src/views/sort-animation.html
+++ b/examples/src/views/sort-animation.html
@@ -1,0 +1,29 @@
+{% extends 'templates/document.html' %}
+
+{% import 'components/Document/Head.html' as Head %}
+{% import 'components/Sidebar/Sidebar.html' as Sidebar %}
+{% import 'components/PageHeader/PageHeader.html' as PageHeader %}
+
+{% import 'content/Plugins/SortAnimation/SortAnimation.html' as SortAnimation %}
+
+{% set ViewAttr = {
+  id: 'SortAnimation',
+  parent: 'Plugins',
+  child: 'Sort Animation',
+  subheading: 'Adds sort animation on all sorted elements with both horizontal and vertical within grid layout'
+} %}
+
+{% block PageId %}{{ ViewAttr.id }}{% endblock %}
+
+{% block head %}
+  {{ Head.render(ViewAttr) }}
+{% endblock %}
+
+{% block sidebar %}
+  {{ Sidebar.render(ViewAttr, DataPages) }}
+{% endblock %}
+
+{% block main %}
+  {{ PageHeader.render(ViewAttr) }}
+  {{ SortAnimation.render(ViewAttr.id) }}
+{% endblock %}

--- a/scripts/build/bundles.js
+++ b/scripts/build/bundles.js
@@ -68,6 +68,13 @@ const bundles = [
     source: 'Plugins/SwapAnimation/index',
     path: 'plugins/',
   },
+
+  {
+    name: 'SortAnimation',
+    filename: 'sort-animation',
+    source: 'Plugins/SortAnimation/index',
+    path: 'plugins/',
+  },
 ];
 
 module.exports = {bundles};

--- a/src/Plugins/SortAnimation/README.md
+++ b/src/Plugins/SortAnimation/README.md
@@ -1,0 +1,63 @@
+## SortAnimation
+
+The sort animation plugin currently only works with `Sortable`. It adds sort animation on `sortable:sorted` with both horizontal and vertical within grid layout,
+and animates all sorted elements via `translate3d`. It is currently possible to change the duration and
+the easing function of the animation.
+
+It different with (SwapAnimation)[https://github.com/Shopify/draggable/tree/master/src/Plugins/SwapAnimation] plugin because SwapAnimation only support horizontal or vertical layout.
+
+This plugin is not included by default, so make sure to import it before using.
+
+**NOTE**: Don't use this plugin with (SwapAnimation)[https://github.com/Shopify/draggable/tree/master/src/Plugins/SwapAnimation] plugin to avoid conflict.
+
+### Import
+
+```js
+import { Plugins } from '@shopify/draggable';
+```
+
+```js
+import SortAnimation from '@shopify/draggable/lib/plugins/sort-animation';
+```
+
+```html
+<script src="https://cdn.jsdelivr.net/npm/@shopify/draggable@1.0.0-beta.8/lib/plugins.js"></script>
+```
+
+```html
+<script src="https://cdn.jsdelivr.net/npm/@shopify/draggable@1.0.0-beta.8/lib/plugins/sort-animation.js"></script>
+```
+
+### API
+
+**`new SortAnimation(draggable: Draggable): SortAnimation`**  
+To create a sort animation plugin instance.
+
+### Options
+
+**`duration {Integer}`**  
+The duration option allows you to specify the animation during for a single sort. Default: `150`
+
+**`easingFunction {String}`**  
+The easing option allows you to specify an animation easing function. Default: `'ease-in-out'`
+
+### Examples
+
+```js
+import { Sortable, Plugins } from '@shopify/draggable';
+
+const sortable = new Sortable(document.querySelectorAll('ul'), {
+  draggable: 'li',
+  sortAnimation: {
+    duration: 200,
+    easingFunction: 'ease-in-out',
+  },
+  plugins: [Plugins.SortAnimation]
+});
+```
+
+### Caveats
+
+- Only works within same container
+- Animations don't stagger
+- Only works with `Sortable`

--- a/src/Plugins/SortAnimation/SortAnimation.js
+++ b/src/Plugins/SortAnimation/SortAnimation.js
@@ -1,0 +1,170 @@
+import AbstractPlugin from 'shared/AbstractPlugin';
+
+const onSortableSorted = Symbol('onSortableSorted');
+const onSortableSort = Symbol('onSortableSort');
+
+/**
+ * SortAnimation default options
+ * @property {Object} defaultOptions
+ * @property {Number} defaultOptions.duration
+ * @property {String} defaultOptions.easingFunction
+ * @type {Object}
+ */
+export const defaultOptions = {
+  duration: 150,
+  easingFunction: 'ease-in-out',
+};
+
+/**
+ * SortAnimation plugin adds sort animation for sortable
+ * @class SortAnimation
+ * @module SortAnimation
+ * @extends AbstractPlugin
+ */
+export default class SortAnimation extends AbstractPlugin {
+  /**
+   * SortAnimation constructor.
+   * @constructs SortAnimation
+   * @param {Draggable} draggable - Draggable instance
+   */
+  constructor(draggable) {
+    super(draggable);
+
+    /**
+     * SortAnimation options
+     * @property {Object} options
+     * @property {Number} defaultOptions.duration
+     * @property {String} defaultOptions.easingFunction
+     * @type {Object}
+     */
+    this.options = {
+      ...defaultOptions,
+      ...this.getOptions(),
+    };
+
+    /**
+     * Last animation frame
+     * @property {Number} lastAnimationFrame
+     * @type {Number}
+     */
+    this.lastAnimationFrame = null;
+    this.lastElements = [];
+
+    this[onSortableSorted] = this[onSortableSorted].bind(this);
+    this[onSortableSort] = this[onSortableSort].bind(this);
+  }
+
+  /**
+   * Attaches plugins event listeners
+   */
+  attach() {
+    this.draggable.on('sortable:sort', this[onSortableSort]);
+    this.draggable.on('sortable:sorted', this[onSortableSorted]);
+  }
+
+  /**
+   * Detaches plugins event listeners
+   */
+  detach() {
+    this.draggable.off('sortable:sort', this[onSortableSort]);
+    this.draggable.off('sortable:sorted', this[onSortableSorted]);
+  }
+
+  /**
+   * Returns options passed through draggable
+   * @return {Object}
+   */
+  getOptions() {
+    return this.draggable.options.sortAnimation || {};
+  }
+
+  /**
+   * Sortable sort handler
+   * @param {SortableSortEvent} sortableEvent
+   * @private
+   */
+  [onSortableSort]({dragEvent}) {
+    const {sourceContainer} = dragEvent;
+    const elements = this.draggable.getDraggableElementsForContainer(sourceContainer);
+    this.lastElements = Array.from(elements).map((el) => {
+      return {
+        domEl: el,
+        offsetTop: el.offsetTop,
+        offsetLeft: el.offsetLeft,
+      };
+    });
+  }
+
+  /**
+   * Sortable sorted handler
+   * @param {SortableSortedEvent} sortableEvent
+   * @private
+   */
+  [onSortableSorted]({oldIndex, newIndex}) {
+    if (oldIndex === newIndex) {
+      return;
+    }
+
+    const effectedElements = [];
+    let start;
+    let end;
+    let num;
+    if (oldIndex > newIndex) {
+      start = newIndex;
+      end = oldIndex - 1;
+      num = 1;
+    } else {
+      start = oldIndex + 1;
+      end = newIndex;
+      num = -1;
+    }
+
+    for (let i = start; i <= end; i++) {
+      const from = this.lastElements[i];
+      const to = this.lastElements[i + num];
+      effectedElements.push({from, to});
+    }
+    cancelAnimationFrame(this.lastAnimationFrame);
+
+    // Can be done in a separate frame
+    this.lastAnimationFrame = requestAnimationFrame(() => {
+      effectedElements.forEach((element) => animate(element, this.options));
+    });
+  }
+}
+
+/**
+ * Animates two elements
+ * @param {Object} element
+ * @param {Object} element.from
+ * @param {Object} element.to
+ * @param {Object} options
+ * @param {Number} options.duration
+ * @param {String} options.easingFunction
+ * @private
+ */
+function animate({from, to}, {duration, easingFunction}) {
+  const domEl = from.domEl;
+  const x = from.offsetLeft - to.offsetLeft;
+  const y = from.offsetTop - to.offsetTop;
+
+  domEl.style.pointerEvents = 'none';
+  domEl.style.transform = `translate3d(${x}px, ${y}px, 0)`;
+
+  requestAnimationFrame(() => {
+    domEl.addEventListener('transitionend', resetElementOnTransitionEnd);
+    domEl.style.transition = `transform ${duration}ms ${easingFunction}`;
+    domEl.style.transform = '';
+  });
+}
+
+/**
+ * Resets animation style properties after animation has completed
+ * @param {Event} event
+ * @private
+ */
+function resetElementOnTransitionEnd(event) {
+  event.target.style.transition = '';
+  event.target.style.pointerEvents = '';
+  event.target.removeEventListener('transitionend', resetElementOnTransitionEnd);
+}

--- a/src/Plugins/SortAnimation/index.js
+++ b/src/Plugins/SortAnimation/index.js
@@ -1,0 +1,4 @@
+import SortAnimation, {defaultOptions} from './SortAnimation';
+
+export default SortAnimation;
+export {defaultOptions};

--- a/src/Plugins/index.js
+++ b/src/Plugins/index.js
@@ -2,3 +2,4 @@ export {default as Collidable} from './Collidable';
 export {default as ResizeMirror, defaultOptions as defaultResizeMirrorOptions} from './ResizeMirror';
 export {default as Snappable} from './Snappable';
 export {default as SwapAnimation, defaultOptions as defaultSwapAnimationOptions} from './SwapAnimation';
+export {default as SortAnimation, defaultOptions as defaultSortAnimationOptions} from './SortAnimation';


### PR DESCRIPTION
### This PR implements SortAnimation plugin (different to SwapAnimation plugin)

I working on my company project and **Draggable** (exactly **Sortable**) really help me to allow my users change these items order by drag and drop. But the animation of SwapAnimation plugin doesn't work fine on grid layout, that need both horizontal and vertical animation and *another elements should be animate too*, not just **source** and **over** elements.

In short, SwapAnimation only create `swap animation` for *source* and **over** elements, SortAnimation create `sort animation` for **all elements** that will be affect (change order) by the sorted event.

So I created this plugin to handle that case, hope it will helpful for someone that working on grid layout (like me :D).

Demo:
![Demo Gif](https://i.imgur.com/gBqCFjr.gif)

### Does this PR require the Docs to be updated?

No, I updated Docs and example for this plugins.

### Does this PR require new tests?

Yes, but I don't know how to test plugin in Draggable, so please help me do it, I really appreciate your help :D

### This branch been tested on... _(click all that apply / add new items)_

**Browsers:**

* [X] Chrome 83.0.4103.97
* [ ] Firefox _version_
* [ ] Safari _version_
* [ ] IE / Edge _version_
* [ ] iOS Browser _version_
* [ ] Android Browser _version_
