### PR TITLE
Add resetMouseSensor to guaranteed all sensor properties is initial properties after cancelled the drag event

### DIFF
--- a/src/Draggable/Sensors/MouseSensor/MouseSensor.js
+++ b/src/Draggable/Sensors/MouseSensor/MouseSensor.js
@@ -7,6 +7,7 @@ const onMouseDown = Symbol('onMouseDown');
 const onMouseMove = Symbol('onMouseMove');
 const onMouseUp = Symbol('onMouseUp');
 const startDrag = Symbol('startDrag');
+const resetMouseSensor = Symbol('resetMouseSensor');
 const onDistanceChange = Symbol('onDistanceChange');
 
 /**
@@ -37,6 +38,7 @@ export default class MouseSensor extends Sensor {
     this[onMouseMove] = this[onMouseMove].bind(this);
     this[onMouseUp] = this[onMouseUp].bind(this);
     this[startDrag] = this[startDrag].bind(this);
+    this[resetMouseSensor] = this[resetMouseSensor].bind(this);
     this[onDistanceChange] = this[onDistanceChange].bind(this);
   }
 
@@ -167,6 +169,7 @@ export default class MouseSensor extends Sensor {
     document.removeEventListener('mousemove', this[onDistanceChange]);
 
     if (!this.dragging) {
+      this[resetMouseSensor]();
       return;
     }
 
@@ -185,11 +188,7 @@ export default class MouseSensor extends Sensor {
     document.removeEventListener('contextmenu', this[onContextMenuWhileDragging], true);
     document.removeEventListener('mousemove', this[onMouseMove]);
 
-    this.currentContainer = null;
-    this.dragging = false;
-    this.distance = 0;
-    this.delayOver = false;
-    this.startEvent = null;
+    this[resetMouseSensor]();
   }
 
   /**
@@ -199,6 +198,18 @@ export default class MouseSensor extends Sensor {
    */
   [onContextMenuWhileDragging](event) {
     event.preventDefault();
+  }
+
+  /**
+   * Reset all value of sensor
+   * @private
+   */
+  [resetMouseSensor]() {
+    this.currentContainer = null;
+    this.dragging = false;
+    this.distance = 0;
+    this.delayOver = false;
+    this.startEvent = null;
   }
 }
 

--- a/src/Draggable/Sensors/TouchSensor/TouchSensor.js
+++ b/src/Draggable/Sensors/TouchSensor/TouchSensor.js
@@ -6,6 +6,7 @@ const onTouchStart = Symbol('onTouchStart');
 const onTouchEnd = Symbol('onTouchEnd');
 const onTouchMove = Symbol('onTouchMove');
 const startDrag = Symbol('startDrag');
+const resetTouchSensor = Symbol('resetTouchSensor');
 const onDistanceChange = Symbol('onDistanceChange');
 
 /**
@@ -69,6 +70,7 @@ export default class TouchSensor extends Sensor {
     this[onTouchEnd] = this[onTouchEnd].bind(this);
     this[onTouchMove] = this[onTouchMove].bind(this);
     this[startDrag] = this[startDrag].bind(this);
+    this[resetTouchSensor] = this[resetTouchSensor].bind(this);
     this[onDistanceChange] = this[onDistanceChange].bind(this);
   }
 
@@ -210,6 +212,7 @@ export default class TouchSensor extends Sensor {
     clearTimeout(this.tapTimeout);
 
     if (!this.dragging) {
+      this[resetTouchSensor]();
       return;
     }
 
@@ -228,6 +231,14 @@ export default class TouchSensor extends Sensor {
 
     this.trigger(this.currentContainer, dragStopEvent);
 
+    this[resetTouchSensor]();
+  }
+
+  /**
+   * Reset all value of sensor
+   * @private
+   */
+  [resetTouchSensor]() {
     this.currentContainer = null;
     this.dragging = false;
     this.distance = 0;


### PR DESCRIPTION
### This PR fixes drag bug when drag event was cancelled
Currently, if the `DragStartEvent` of `MouseSensor` (and `TouchSensor`) was cancelled, properties of the sensor weren't reset, it will create wrong behaviour of the next `DragStartEvent` of this sensor.

The problem was described in #401 

Thanks to @zjffun , in the first I don't know the problem is in MouseSensor 😄 

### This PR closes the following issues: 
#401 

### Does this PR require the Docs to be updated?
No

### Does this PR require new tests?
No

### This branch been tested on

**Browsers:**

* [x] Chrome latest
* [x] Firefox latest
* [x] Safari latest
* [ ] IE / Edge _version_
* [ ] iOS Browser _version_
* [ ] Android Browser _version_
