### PR TITLE
Add `exclude` field to Draggable options to allow disable default plugins and sensors

### DIFF
--- a/src/Draggable/Draggable.js
+++ b/src/Draggable/Draggable.js
@@ -52,6 +52,10 @@ export const defaultOptions = {
   placedTimeout: 800,
   plugins: [],
   sensors: [],
+  exclude: {
+    plugins: [],
+    sensors: [],
+  },
 };
 
 /**
@@ -71,6 +75,16 @@ export default class Draggable {
    * @type {Object}
    */
   static Plugins = {Announcement, Focusable, Mirror, Scrollable};
+
+  /**
+   * Default sensors draggable uses
+   * @static
+   * @property {Object} Sensors
+   * @property {MouseSensor} Sensors.MouseSensor
+   * @property {TouchSensor} Sensors.TouchSensor
+   * @type {Object}
+   */
+  static Sensors = {MouseSensor, TouchSensor};
 
   /**
    * Draggable constructor.
@@ -102,6 +116,10 @@ export default class Draggable {
       announcements: {
         ...defaultAnnouncements,
         ...(options.announcements || {}),
+      },
+      exclude: {
+        plugins: (options.exclude && options.exclude.plugins) || [],
+        sensors: (options.exclude && options.exclude.sensors) || [],
       },
     };
 
@@ -143,8 +161,12 @@ export default class Draggable {
     document.addEventListener('drag:stop', this[onDragStop], true);
     document.addEventListener('drag:pressure', this[onDragPressure], true);
 
-    const defaultPlugins = Object.values(Draggable.Plugins).map((Plugin) => Plugin);
-    const defaultSensors = [MouseSensor, TouchSensor];
+    const defaultPlugins = Object.values(Draggable.Plugins).filter(
+      (Plugin) => !this.options.exclude.plugins.includes(Plugin),
+    );
+    const defaultSensors = Object.values(Draggable.Sensors).filter(
+      (sensor) => !this.options.exclude.sensors.includes(sensor),
+    );
 
     this.addPlugin(...[...defaultPlugins, ...this.options.plugins]);
     this.addSensor(...[...defaultSensors, ...this.options.sensors]);

--- a/src/Draggable/Plugins/Focusable/Focusable.js
+++ b/src/Draggable/Plugins/Focusable/Focusable.js
@@ -51,6 +51,9 @@ export default class Focusable extends AbstractPlugin {
    */
   detach() {
     this.draggable.off('draggable:initialize', this[onInitialize]).off('draggable:destroy', this[onDestroy]);
+
+    // Remove modified elements when detach
+    this[onDestroy]();
   }
 
   /**

--- a/src/Draggable/README.md
+++ b/src/Draggable/README.md
@@ -96,6 +96,9 @@ By default draggable includes the `MouseSensor` & `TouchSensor`. Default: `[]`
 Draggable adds classes to elements to indicate state. These classes can be used to add styling
 on elements in certain states.
 
+**`exclude {plugins: Plugin[], sensors: Sensor[]}`**  
+Allow excluding default plugins and default sensors. Use with caution as it may create strange behavior.
+
 ### Events
 
 | Name                                       | Description                                               | Cancelable | Cancelable action   |
@@ -150,4 +153,18 @@ const draggable = new Draggable(document.querySelectorAll('ul'), {
 draggable.on('drag:start', () => console.log('drag:start'));
 draggable.on('drag:move', () => console.log('drag:move'));
 draggable.on('drag:stop', () => console.log('drag:stop'));
+```
+
+Create draggable which excluded some default plugins and sensor:
+
+```js
+import { Draggable } from '@shopify/draggable';
+
+const draggable = new Draggable(document.querySelectorAll('ul'), {
+  draggable: 'li',
+  exclude: {
+    plugins: [Draggable.Plugins.Focusable],
+    sensors: [Draggable.Sensors.TouchSensor],
+  }
+});
 ```

--- a/src/Draggable/tests/Draggable.test.js
+++ b/src/Draggable/tests/Draggable.test.js
@@ -64,7 +64,7 @@ describe('Draggable', () => {
 
       for (const key in defaultOptions) {
         if (defaultOptions.hasOwnProperty(key)) {
-          expect(newInstance.options[key]).toBe(defaultOptions[key]);
+          expect(newInstance.options[key]).toEqual(defaultOptions[key]);
         }
       }
     });
@@ -105,6 +105,20 @@ describe('Draggable', () => {
       expect(newInstance.plugins[3]).toBeInstanceOf(Scrollable);
     });
 
+    it('should remove default plugins from the list of exclude plugins', () => {
+      const newInstance = new Draggable([], {
+        exclude: {
+          plugins: [Draggable.Plugins.Focusable],
+        },
+      });
+
+      expect(newInstance.plugins).toHaveLength(3);
+
+      newInstance.plugins.forEach((plugin) => {
+        expect(plugin).not.toBeInstanceOf(Focusable);
+      });
+    });
+
     it('should attach custom plugins', () => {
       const newInstance = new Draggable([], {
         plugins: [TestPlugin],
@@ -131,6 +145,20 @@ describe('Draggable', () => {
       expect(newInstance.sensors[0]).toBeInstanceOf(MouseSensor);
 
       expect(newInstance.sensors[1]).toBeInstanceOf(TouchSensor);
+    });
+
+    it('should remove default sensors from the list of exclude sensors', () => {
+      const newInstance = new Draggable([], {
+        exclude: {
+          sensors: [Draggable.Sensors.TouchSensor],
+        },
+      });
+
+      expect(newInstance.sensors).toHaveLength(1);
+
+      newInstance.sensors.forEach((sensor) => {
+        expect(sensor).not.toBeInstanceOf(TouchSensor);
+      });
     });
 
     it('should trigger DraggableInitializedEvent on init', () => {


### PR DESCRIPTION
### This PR implements "exclude" option to allow disable default plugins and sensors

Some default plugins of **Draggable** is not necessary for some scenarios. For example, **Focusable** will create unexpected behavior in case users want to make these own keyboard control.

On the other side, this feature will allow the user to replace default plugins/sensors with these own plugins/sensors.

Below is a sample usage of **exclude** field:

```
import { Draggable } from '@shopify/draggable';

const draggable = new Draggable(document.querySelectorAll('ul'), {
  draggable: 'li',
  exclude: {
    plugins: [Draggable.Plugins.Focusable],
    sensors: [Draggable.Sensors.TouchSensor],
  }
});
```

So I create this PR to add the ability to exclude default plugins and sensors. Feel free to request any changes if you have a better way to achieve it. 😄 

### This PR closes the following issues
#372 , #317 

### Does this PR require the Docs to be updated?
Yes, I updated it.

### Does this PR require new tests?
Yes, I updated it.

### This branch been tested on:

* [x] Chrome latest
* [x] Firefox latest
* [x] Safari latest
* [ ] IE / Edge _version_
* [ ] iOS Browser _version_
* [ ] Android Browser _version_
