### PR TITLE
fix(examples): prevent press drag block to display menu

### DIFF
--- a/examples/src/components/Block/Block.html
+++ b/examples/src/components/Block/Block.html
@@ -15,8 +15,8 @@
   {% set classes = classes | join(' ') | trim %}
 
   {% if options.draggable %}
-    {% set openingTag = '<a href="#" class="' + classes + '" title="Click to drag">' %}
-    {% set closingTag = '</a>' %}
+    {% set openingTag = '<span class="' + classes + '" title="Click to drag">' %}
+    {% set closingTag = '</span>' %}
   {% else %}
     {% set openingTag = '<span class="' + classes + '">' %}
     {% set closingTag = '</span>' %}

--- a/examples/src/components/PillSwitch/PillSwitch.html
+++ b/examples/src/components/PillSwitch/PillSwitch.html
@@ -4,8 +4,8 @@
       <div class="Pattern Pattern--typeHalftone"></div>
     </div>
 
-    <a href="#" class="PillSwitchControl">
+    <span class="PillSwitchControl">
       <p class="Heading Heading--sizeJumbo text-no-select" data-switch-off="off" data-switch-on="on">off</p>
-    </a>
+    </span>
   </article>
 {% endmacro %}

--- a/examples/src/components/Plate/Plate.html
+++ b/examples/src/components/Plate/Plate.html
@@ -12,8 +12,8 @@
   {% set classes = classes | join(' ') | trim %}
 
   {% if options.draggable %}
-    {% set openingTag = '<a href="#" class="' + classes + '" title="Click to drag">' %}
-    {% set closingTag = '</a>' %}
+    {% set openingTag = '<span class="' + classes + '" title="Click to drag">' %}
+    {% set closingTag = '</span>' %}
   {% else %}
     {% set openingTag = '<span class="' + classes + '">' %}
     {% set closingTag = '</span>' %}


### PR DESCRIPTION
Rendering drag blocks with `<a>` will display menu when press on mobile browser.

### This PR fixes exmaples

### This PR closes the following issues... _(if applicable)_

No

### Does this PR require the Docs to be updated?

No

### Does this PR require new tests?

No

### This branch been tested on... _(click all that apply / add new items)_

**Browsers:**

* [x] Chrome _version_
* [x] Firefox _version_
* [ ] Safari _version_
* [ ] IE / Edge _version_
* [x] iOS Browser _version_
* [ ] Android Browser _version_
