### PR TITLE
fix: Nested Sortable issues

### DIFF
--- a/src/Sortable/Sortable.js
+++ b/src/Sortable/Sortable.js
@@ -105,7 +105,23 @@ export default class Sortable extends Draggable {
    * @return {Number}
    */
   index(element) {
-    return this.getDraggableElementsForContainer(element.parentNode).indexOf(element);
+    return this.getSortableElementsForContainer(element.parentNode).indexOf(element);
+  }
+
+  /**
+   * Returns sortable elements for a given container, excluding the mirror and
+   * original source element if present
+   * @param {HTMLElement} container
+   * @return {HTMLElement[]}
+   */
+  getSortableElementsForContainer(container) {
+    const allSortableElements = container.querySelectorAll(this.options.draggable);
+
+    return [...allSortableElements].filter((childElement) => {
+      return (
+        childElement !== this.originalSource && childElement !== this.mirror && childElement.parentNode === container
+      );
+    });
   }
 
   /**
@@ -156,7 +172,7 @@ export default class Sortable extends Draggable {
       return;
     }
 
-    const children = this.getDraggableElementsForContainer(overContainer);
+    const children = this.getSortableElementsForContainer(overContainer);
     const moves = move({source, over, overContainer, children});
 
     if (!moves) {
@@ -252,7 +268,7 @@ function index(element) {
 function move({source, over, overContainer, children}) {
   const emptyOverContainer = !children.length;
   const differentContainer = source.parentNode !== overContainer;
-  const sameContainer = over && !differentContainer;
+  const sameContainer = over && source.parentNode === over.parentNode;
 
   if (emptyOverContainer) {
     return moveInsideEmptyContainer(source, overContainer);


### PR DESCRIPTION
### This PR fixes
1. Issues with nested Sortables, particularly incorrect value of oldIndex, and console errors while dragging items around.

### This PR closes the following issues
1. [BUG] Incorrect oldIndex when there are nested draggable containers #427 

### Does this PR require the Docs to be updated?
No

### Does this PR require new tests?
Not sure

### This branch been tested on

**Browsers:**

* [ ] Chrome 84
* [ ] IE / Edge 84
