### PR TITLE
Update outdated parts of documentation

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,13 +5,12 @@ appreciated and encouraged.
 
 ## Table of contents
 
-1. [Code of Conduct](code-of-conduct)
-2. [How to contribute](how-to-contribute)
-    1. [Creating issues](creating-issues)
-    2. [Opening pull requests](opening-pull-requests)
-    3. [JS Docblocks](js-docblocks)
-4. [How to run locally](how-to-run-locally)
-3. [Additional information](additional-information)
+1. [Code of Conduct](#code-of-conduct)
+2. [How to contribute](#how-to-contribute)
+    1. [Creating issues](#creating-issues)
+    2. [Opening pull requests](#opening-pull-requests)
+    3. [JS Docblocks](#js-docblocks)
+4. [How to run locally](#how-to-run-locally)
 
 ## Code of Conduct
 

--- a/src/Draggable/README.md
+++ b/src/Draggable/README.md
@@ -1,21 +1,36 @@
 ## Draggable
 
-### Import
+### Usage
 
+- ES6:
 ```js
 import { Draggable } from '@shopify/draggable';
+// Or
+// import Draggable from '@shopify/draggable/lib/draggable';
+
+const draggable = new Draggable(document.querySelectorAll('ul'), {
+  draggable: 'li'
+});
 ```
 
-```js
-import Draggable from '@shopify/draggable/lib/draggable';
-```
-
+- Browser (All Bundle):
 ```html
 <script src="https://cdn.jsdelivr.net/npm/@shopify/draggable@1.0.0-beta.11/lib/draggable.bundle.js"></script>
+<script>
+    const draggable = new Draggable.Draggable(document.querySelectorAll('ul'), {
+      draggable: 'li'
+    });
+</script>
 ```
 
+- Browser (Standalone):
 ```html
 <script src="https://cdn.jsdelivr.net/npm/@shopify/draggable@1.0.0-beta.11/lib/draggable.js"></script>
+<script>
+    const draggable = new Draggable.default(document.querySelectorAll('ul'), {
+      draggable: 'li'
+    });
+</script>
 ```
 
 ### API

--- a/src/Droppable/README.md
+++ b/src/Droppable/README.md
@@ -5,22 +5,40 @@ Droppable fires two events on top of the draggable events: `droppable:dropped` a
 Droppable elements must begin in an occupied dropzone (see below, [Classes](#classes) and example),
 so they may returned if the drag is canceled or returned.
 
-### Import
+### Usage
 
+- ES6:
 ```js
 import { Droppable } from '@shopify/draggable';
+// Or
+// import Droppable from '@shopify/draggable/lib/droppable';
+
+const droppable = new Droppable(document.querySelectorAll('.container'), {
+  draggable: '.item',
+  dropzone: '.dropzone'
+});
 ```
 
-```js
-import Droppable from '@shopify/draggable/lib/droppable';
-```
-
+- Browser (All Bundle):
 ```html
 <script src="https://cdn.jsdelivr.net/npm/@shopify/draggable@1.0.0-beta.11/lib/draggable.bundle.js"></script>
+<script>
+    const droppable = new Draggable.Droppable(document.querySelectorAll('.container'), {
+      draggable: '.item',
+      dropzone: '.dropzone'
+    });
+</script>
 ```
 
+- Browser (Standalone):
 ```html
 <script src="https://cdn.jsdelivr.net/npm/@shopify/draggable@1.0.0-beta.11/lib/droppable.js"></script>
+<script>
+    const droppable = new Droppable.default(document.querySelectorAll('.container'), {
+      draggable: '.item',
+      dropzone: '.dropzone'
+    });
+</script>
 ```
 
 ### API

--- a/src/Plugins/Collidable/README.md
+++ b/src/Plugins/Collidable/README.md
@@ -5,22 +5,45 @@ the mirror movement for you. These currently only work with `Sortable`, `Swappab
 
 This plugin is not included by default, so make sure to import it before using.
 
-### Import
+### Usage
 
+- ES6:
 ```js
-import { Plugins } from '@shopify/draggable';
+import { Draggable, Plugins } from "@shopify/draggable";
+// Or
+// import Draggable from '@shopify/draggable/lib/draggable';
+// import Collidable from '@shopify/draggable/lib/plugins/collidable';
+
+const draggable = new Draggable(document.querySelectorAll("ul"), {
+  draggable: "li",
+  collidables: ".other-list",
+  plugins: [Plugins.Collidable], // Or [Collidable]
+});
 ```
 
-```js
-import Collidable from '@shopify/draggable/lib/plugins/collidable';
-```
-
+- Browser (All bundle):
 ```html
-<script src="https://cdn.jsdelivr.net/npm/@shopify/draggable@1.0.0-beta.11/lib/plugins.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/@shopify/draggable@1.0.0-beta.11/lib/draggable.bundle.js"></script>
+<script>
+    const draggable = new Draggable.Draggable(document.querySelectorAll('ul'), {
+      draggable: 'li',
+      collidables: '.other-list',
+      plugins: [Draggable.Plugins.Collidable]
+    });
+</script>
 ```
 
+- Browser (Standalone):
 ```html
+<script src="https://cdn.jsdelivr.net/npm/@shopify/draggable@1.0.0-beta.11/lib/draggable.js"></script>
 <script src="https://cdn.jsdelivr.net/npm/@shopify/draggable@1.0.0-beta.11/lib/plugins/collidable.js"></script>
+<script>
+    const draggable = new Draggable.default(document.querySelectorAll('ul'), {
+      draggable: 'li',
+      collidables: '.other-list',
+      plugins: [Collidable.default]
+    });
+</script>
 ```
 
 ### Options

--- a/src/Plugins/ResizeMirror/README.md
+++ b/src/Plugins/ResizeMirror/README.md
@@ -11,22 +11,42 @@ This plugin is not included in the default Draggable bundle, so you'll need to i
 
 > **Example of `ResizeMirror` in action.** Custom transitions are applied via CSS _(not provided by the plugin)_ – [Grid Layout Example](https://shopify.github.io/draggable/examples/grid-layout.html)
 
-### Import
+### Usage
 
+- ES6:
 ```js
-import { Plugins } from '@shopify/draggable';
+import { Draggable, Plugins } from "@shopify/draggable";
+// Or
+// import Draggable from '@shopify/draggable/lib/draggable';
+// import ResizeMirror from '@shopify/draggable/lib/plugins/resize-mirror';
+
+const draggable = new Draggable(document.querySelectorAll('ul'), {
+  draggable: 'li',
+  plugins: [Plugins.ResizeMirror] // Or [ResizeMirror]
+});
 ```
 
-```js
-import ResizeMirror from '@shopify/draggable/lib/plugins/resize-mirror';
-```
-
+- Browser (All bundle):
 ```html
-<script src="https://cdn.jsdelivr.net/npm/@shopify/draggable@1.0.0-beta.11/lib/plugins.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/@shopify/draggable@1.0.0-beta.11/lib/draggable.bundle.js"></script>
+<script>
+    const draggable = new Draggable.Draggable(document.querySelectorAll('ul'), {
+      draggable: 'li',
+      plugins: [Draggable.Plugins.ResizeMirror]
+    });
+</script>
 ```
 
+- Browser (Standalone):
 ```html
+<script src="https://cdn.jsdelivr.net/npm/@shopify/draggable@1.0.0-beta.11/lib/draggable.js"></script>
 <script src="https://cdn.jsdelivr.net/npm/@shopify/draggable@1.0.0-beta.11/lib/plugins/resize-mirror.js"></script>
+<script>
+    const draggable = new Draggable.default(document.querySelectorAll('ul'), {
+      draggable: 'li',
+      plugins: [ResizeMirror.default]
+    });
+</script>
 ```
 
 ### API

--- a/src/Plugins/Snappable/README.md
+++ b/src/Plugins/Snappable/README.md
@@ -5,22 +5,43 @@ It also sets the `'source:placed'` class for potential drop animations.
 
 This plugin is not included by default, so make sure to import it before using.
 
-### Import
+### Usage
 
+- ES6:
 ```js
-import { Plugins } from '@shopify/draggable';
+import { Draggable, Plugins } from "@shopify/draggable";
+// Or
+// import Draggable from '@shopify/draggable/lib/draggable';
+// import Snappable from '@shopify/draggable/lib/plugins/snappable';
+
+
+const draggable = new Draggable(document.querySelectorAll('ul'), {
+  draggable: 'li',
+  plugins: [Plugins.Snappable] // Or [Snappable]
+});
 ```
 
-```js
-import Snappable from '@shopify/draggable/lib/plugins/snappable';
-```
-
+- Browser (All bundle):
 ```html
-<script src="https://cdn.jsdelivr.net/npm/@shopify/draggable@1.0.0-beta.11/lib/plugins.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/@shopify/draggable@1.0.0-beta.11/lib/draggable.bundle.js"></script>
+<script>
+    const draggable = new Draggable.Draggable(document.querySelectorAll('ul'), {
+      draggable: 'li',
+      plugins: [Draggable.Plugins.Snappable]
+    });
+</script>
 ```
 
+- Browser (Standalone):
 ```html
+<script src="https://cdn.jsdelivr.net/npm/@shopify/draggable@1.0.0-beta.11/lib/draggable.js"></script>
 <script src="https://cdn.jsdelivr.net/npm/@shopify/draggable@1.0.0-beta.11/lib/plugins/snappable.js"></script>
+<script>
+    const draggable = new Draggable.default(document.querySelectorAll('ul'), {
+      draggable: 'li',
+      plugins: [Snappable.default]
+    });
+</script>
 ```
 
 ### Options

--- a/src/Plugins/SortAnimation/README.md
+++ b/src/Plugins/SortAnimation/README.md
@@ -10,22 +10,54 @@ This plugin is not included by default, so make sure to import it before using.
 
 **NOTE**: Don't use this plugin with [SwapAnimation](https://github.com/Shopify/draggable/tree/master/src/Plugins/SwapAnimation) plugin to avoid conflict.
 
-### Import
+### Usage
 
+- ES6:
 ```js
-import { Plugins } from '@shopify/draggable';
+import { Sortable, Plugins } from "@shopify/draggable";
+// Or
+// import Sortable from '@shopify/draggable/lib/sortable';
+// import SortAnimation from '@shopify/draggable/lib/plugins/sort-animation';
+
+const sortable = new Sortable(document.querySelectorAll('ul'), {
+  draggable: 'li',
+  sortAnimation: {
+    duration: 200,
+    easingFunction: 'ease-in-out',
+  },
+  plugins: [Plugins.SortAnimation] // Or [SortAnimation]
+});
 ```
 
-```js
-import SortAnimation from '@shopify/draggable/lib/plugins/sort-animation';
-```
-
+- Browser (All plugins bundle):
 ```html
-<script src="https://cdn.jsdelivr.net/npm/@shopify/draggable@1.0.0-beta.11/lib/plugins.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/@shopify/draggable@1.0.0-beta.11/lib/draggable.bundle.js"></script>
+<script>
+    const sortable = new Draggable.Sortable(document.querySelectorAll('ul'), {
+      draggable: 'li',
+      sortAnimation: {
+        duration: 200,
+        easingFunction: 'ease-in-out',
+      },
+      plugins: [Draggable.Plugins.SortAnimation]
+    });
+</script>
 ```
 
+- Browser (Standalone):
 ```html
+<script src="https://cdn.jsdelivr.net/npm/@shopify/draggable@1.0.0-beta.11/lib/sortable.js"></script>
 <script src="https://cdn.jsdelivr.net/npm/@shopify/draggable@1.0.0-beta.11/lib/plugins/sort-animation.js"></script>
+<script>
+    const sortable = new Sortable.default(document.querySelectorAll('ul'), {
+      draggable: 'li',
+      sortAnimation: {
+        duration: 200,
+        easingFunction: 'ease-in-out',
+      },
+      plugins: [SortAnimation.default]
+    });
+</script>
 ```
 
 ### API

--- a/src/Plugins/SwapAnimation/README.md
+++ b/src/Plugins/SwapAnimation/README.md
@@ -6,22 +6,58 @@ the easing function of the animation.
 
 This plugin is not included by default, so make sure to import it before using.
 
-### Import
+### Usage
 
+- ES6:
 ```js
-import { Plugins } from '@shopify/draggable';
+import { Sortable, Plugins } from "@shopify/draggable";
+// Or
+// import Sortable from '@shopify/draggable/lib/sortable';
+// import SwapAnimation from '@shopify/draggable/lib/plugins/swap-animation';
+
+
+const sortable = new Sortable(document.querySelectorAll('ul'), {
+  draggable: 'li',
+  swapAnimation: {
+    duration: 200,
+    easingFunction: 'ease-in-out',
+    horizontal: true
+  },
+  plugins: [Plugins.SwapAnimation] // Or [SwapAnimation]
+});
 ```
 
-```js
-import SwapAnimation from '@shopify/draggable/lib/plugins/swap-animation';
-```
-
+- Browser (All plugins bundle):
 ```html
-<script src="https://cdn.jsdelivr.net/npm/@shopify/draggable@1.0.0-beta.11/lib/plugins.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/@shopify/draggable@1.0.0-beta.11/lib/draggable.bundle.js"></script>
+<script>
+    const sortable = new Draggable.Sortable(document.querySelectorAll('ul'), {
+      draggable: 'li',
+      swapAnimation: {
+        duration: 200,
+        easingFunction: 'ease-in-out',
+        horizontal: true
+      },
+      plugins: [Draggable.Plugins.SwapAnimation]
+    });
+</script>
 ```
 
+- Browser (Standalone):
 ```html
+<script src="https://cdn.jsdelivr.net/npm/@shopify/draggable@1.0.0-beta.11/lib/sortable.js"></script>
 <script src="https://cdn.jsdelivr.net/npm/@shopify/draggable@1.0.0-beta.11/lib/plugins/swap-animation.js"></script>
+<script>
+    const sortable = new Sortable.default(document.querySelectorAll('ul'), {
+      draggable: 'li',
+      swapAnimation: {
+        duration: 200,
+        easingFunction: 'ease-in-out',
+        horizontal: true
+      },
+      plugins: [SwapAnimation.default]
+    });
+</script>
 ```
 
 ### API

--- a/src/Sortable/README.md
+++ b/src/Sortable/README.md
@@ -5,22 +5,37 @@ three events on top of the draggable events: `sortable:start`, `sortable:sort`, 
 
 Make sure to nest draggable elements as immediate children elements to their corresponding containers, this is a requirement for `Sortable`.
 
-### Import
+### Usage
 
+- ES6:
 ```js
 import { Sortable } from '@shopify/draggable';
+// Or
+// import Sortable from '@shopify/draggable/lib/sortable';
+
+const sortable = new Sortable(document.querySelectorAll('ul'), {
+  draggable: 'li'
+});
 ```
 
-```js
-import Sortable from '@shopify/draggable/lib/sortable';
-```
-
+- Browser (All Bundle):
 ```html
 <script src="https://cdn.jsdelivr.net/npm/@shopify/draggable@1.0.0-beta.11/lib/draggable.bundle.js"></script>
+<script>
+    const sortable = new Draggable.Sortable(document.querySelectorAll('ul'), {
+      draggable: 'li'
+    });
+</script>
 ```
 
+- Browser (Standalone):
 ```html
 <script src="https://cdn.jsdelivr.net/npm/@shopify/draggable@1.0.0-beta.11/lib/sortable.js"></script>
+<script>
+    const sortable = new Sortable.default(document.querySelectorAll('ul'), {
+      draggable: 'li'
+    });
+</script>
 ```
 
 ### API

--- a/src/Sortable/SortableEvent/README.md
+++ b/src/Sortable/SortableEvent/README.md
@@ -48,17 +48,14 @@ Read-only property for the start container of the current draggable source.
 
 ### API
 
-**`sortableEvent.oldIndex: Number`**  
-Read-only property for the old index of the current draggable source.
+**`sortableEvent.currentIndex: Number`**  
+Read-only property for the index of the current draggable source.
 
-**`sortableEvent.newIndex: Number`**  
-Read-only property for the new index of the current draggable source.
+**`sortableEvent.over: HTMLElement`**  
+Read-only property for the draggable source you are hovering over.
 
-**`sortableEvent.oldContainer: HTMLElement`**  
-Read-only property for the old container of the current draggable source.
-
-**`sortableEvent.newContainer: HTMLElement`**  
-Read-only property for the new container of the current draggable source.
+**`sortableEvent.overContainer: HTMLElement`**  
+Read-only property for the container of the draggable source you are hovering over.
 
 ## SortableSortedEvent
 

--- a/src/Swappable/README.md
+++ b/src/Swappable/README.md
@@ -3,22 +3,37 @@
 Swappable is built on top of Draggable and allows you to swap elements by dragging over them. No order will be maintained (unlike Sortable),
 so any draggable element that gets dragged over will be swapped with the source element.
 
-### Import
+### Usage
 
+- ES6:
 ```js
 import { Swappable } from '@shopify/draggable';
+// Or
+// import Swappable from '@shopify/draggable/lib/swappable';
+
+const swappable = new Swappable(document.querySelectorAll('ul'), {
+  draggable: 'li'
+});
 ```
 
-```js
-import Swappable from '@shopify/draggable/lib/swappable';
-```
-
+- Browser (All Bundle):
 ```html
 <script src="https://cdn.jsdelivr.net/npm/@shopify/draggable@1.0.0-beta.11/lib/draggable.bundle.js"></script>
+<script>
+    const swappable = new Draggable.Swappable(document.querySelectorAll('ul'), {
+      draggable: 'li'
+    });
+</script>
 ```
 
+- Browser (Standalone):
 ```html
 <script src="https://cdn.jsdelivr.net/npm/@shopify/draggable@1.0.0-beta.11/lib/swappable.js"></script>
+<script>
+    const swappable = new Swappable.default(document.querySelectorAll('ul'), {
+      draggable: 'li'
+    });
+</script>
 ```
 
 ### API

--- a/src/shared/AbstractEvent/README.md
+++ b/src/shared/AbstractEvent/README.md
@@ -16,7 +16,7 @@ your own custom events.
 **`new AbstractEvent(data: Object): AbstractEvent`**  
 Creates an `AbstractEvent` instance.
 
-**`abstractEvent.cancel(data: Object): null`**  
+**`abstractEvent.cancel(): void`**  
 Cancels drag start event.
 
 **`abstractEvent.canceled(): Boolean`**  
@@ -25,5 +25,9 @@ Checks if event has been canceled.
 **`abstractEvent.type: String`**  
 Read-only property to find out event type
 
-**`abstractEvent.cancelable: String`**  
+**`abstractEvent.cancelable: Boolean`**  
 Read-only property to check if event is cancelable
+
+**`abstractEvent.clone(data: Object): AbstractEvent`**  
+Creates an `AbstractEvent` instance with existing event data. This method allows
+for overriding of event data.


### PR DESCRIPTION
### This PR update outdated parts of current documentation:
- Usage of all Draggable variant.
- Usage of all Draggable plugins
- Contributing documentation
- Some wrong events docs (Sortable events and Abstract event)

### This PR closes the following issues
#418 , #373 , #343 
…

### Does this PR require new tests?
No

### This branch been tested on
* [x] Chrome latest
* [x] Safari latest