### PR TITLE
Allow specifying an array of classNames

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -176,7 +176,7 @@ declare module '@shopify/draggable' {
         delay?: number | DelayOptions;
         plugins?: Array<typeof AbstractPlugin>;
         sensors?: Sensor[];
-        classes?: { [key in DraggableClassNames]: string };
+        classes?: { [key in DraggableClassNames]: string | string[] };
         announcements?: AnnouncementOptions;
         collidables?: Collidables;
         mirror?: MirrorOptions;
@@ -204,6 +204,7 @@ declare module '@shopify/draggable' {
         addContainer(...containers: HTMLElement[]): this;
         removeContainer(...containers: HTMLElement[]): this;
         getClassNameFor(name: DraggableClassNames): string;
+        getClassNamesFor(name: DraggableClassNames): string[];
         isDragging(): boolean;
         getDraggableElementsForContainer(container: HTMLElement): HTMLElement[];
     }

--- a/src/Draggable/Draggable.js
+++ b/src/Draggable/Draggable.js
@@ -329,7 +329,23 @@ export default class Draggable {
    * @return {String|null}
    */
   getClassNameFor(name) {
-    return this.options.classes[name];
+    return this.getClassNamesFor(name)[0];
+  }
+
+  /**
+   * Returns class names for class identifier
+   * @return {String[]}
+   */
+  getClassNamesFor(name) {
+    const classNames = this.options.classes[name];
+
+    if (classNames instanceof Array) {
+      return classNames;
+    } else if (typeof classNames === 'string' || classNames instanceof String) {
+      return [classNames];
+    } else {
+      return [];
+    }
   }
 
   /**
@@ -393,8 +409,8 @@ export default class Draggable {
 
     if (this.lastPlacedSource && this.lastPlacedContainer) {
       clearTimeout(this.placedTimeoutID);
-      this.lastPlacedSource.classList.remove(this.getClassNameFor('source:placed'));
-      this.lastPlacedContainer.classList.remove(this.getClassNameFor('container:placed'));
+      this.lastPlacedSource.classList.remove(...this.getClassNamesFor('source:placed'));
+      this.lastPlacedContainer.classList.remove(...this.getClassNamesFor('container:placed'));
     }
 
     this.source = this.originalSource.cloneNode(true);
@@ -418,10 +434,10 @@ export default class Draggable {
       return;
     }
 
-    this.originalSource.classList.add(this.getClassNameFor('source:original'));
-    this.source.classList.add(this.getClassNameFor('source:dragging'));
-    this.sourceContainer.classList.add(this.getClassNameFor('container:dragging'));
-    document.body.classList.add(this.getClassNameFor('body:dragging'));
+    this.originalSource.classList.add(...this.getClassNamesFor('source:original'));
+    this.source.classList.add(...this.getClassNamesFor('source:dragging'));
+    this.sourceContainer.classList.add(...this.getClassNamesFor('container:dragging'));
+    document.body.classList.add(...this.getClassNamesFor('body:dragging'));
     applyUserSelect(document.body, 'none');
 
     requestAnimationFrame(() => {
@@ -479,7 +495,7 @@ export default class Draggable {
         over: this.currentOver,
       });
 
-      this.currentOver.classList.remove(this.getClassNameFor('draggable:over'));
+      this.currentOver.classList.remove(...this.getClassNamesFor('draggable:over'));
       this.currentOver = null;
 
       this.trigger(dragOutEvent);
@@ -494,14 +510,14 @@ export default class Draggable {
         overContainer: this.currentOverContainer,
       });
 
-      this.currentOverContainer.classList.remove(this.getClassNameFor('container:over'));
+      this.currentOverContainer.classList.remove(...this.getClassNamesFor('container:over'));
       this.currentOverContainer = null;
 
       this.trigger(dragOutContainerEvent);
     }
 
     if (isOverContainer) {
-      overContainer.classList.add(this.getClassNameFor('container:over'));
+      overContainer.classList.add(...this.getClassNamesFor('container:over'));
 
       const dragOverContainerEvent = new DragOverContainerEvent({
         source: this.source,
@@ -517,7 +533,7 @@ export default class Draggable {
     }
 
     if (isOverDraggable) {
-      target.classList.add(this.getClassNameFor('draggable:over'));
+      target.classList.add(...this.getClassNamesFor('draggable:over'));
 
       const dragOverEvent = new DragOverEvent({
         source: this.source,
@@ -559,20 +575,20 @@ export default class Draggable {
     this.source.parentNode.removeChild(this.source);
     this.originalSource.style.display = '';
 
-    this.source.classList.remove(this.getClassNameFor('source:dragging'));
-    this.originalSource.classList.remove(this.getClassNameFor('source:original'));
-    this.originalSource.classList.add(this.getClassNameFor('source:placed'));
-    this.sourceContainer.classList.add(this.getClassNameFor('container:placed'));
-    this.sourceContainer.classList.remove(this.getClassNameFor('container:dragging'));
-    document.body.classList.remove(this.getClassNameFor('body:dragging'));
+    this.source.classList.remove(...this.getClassNamesFor('source:dragging'));
+    this.originalSource.classList.remove(...this.getClassNamesFor('source:original'));
+    this.originalSource.classList.add(...this.getClassNamesFor('source:placed'));
+    this.sourceContainer.classList.add(...this.getClassNamesFor('container:placed'));
+    this.sourceContainer.classList.remove(...this.getClassNamesFor('container:dragging'));
+    document.body.classList.remove(...this.getClassNamesFor('body:dragging'));
     applyUserSelect(document.body, '');
 
     if (this.currentOver) {
-      this.currentOver.classList.remove(this.getClassNameFor('draggable:over'));
+      this.currentOver.classList.remove(...this.getClassNamesFor('draggable:over'));
     }
 
     if (this.currentOverContainer) {
-      this.currentOverContainer.classList.remove(this.getClassNameFor('container:over'));
+      this.currentOverContainer.classList.remove(...this.getClassNamesFor('container:over'));
     }
 
     this.lastPlacedSource = this.originalSource;
@@ -580,11 +596,11 @@ export default class Draggable {
 
     this.placedTimeoutID = setTimeout(() => {
       if (this.lastPlacedSource) {
-        this.lastPlacedSource.classList.remove(this.getClassNameFor('source:placed'));
+        this.lastPlacedSource.classList.remove(...this.getClassNamesFor('source:placed'));
       }
 
       if (this.lastPlacedContainer) {
-        this.lastPlacedContainer.classList.remove(this.getClassNameFor('container:placed'));
+        this.lastPlacedContainer.classList.remove(...this.getClassNamesFor('container:placed'));
       }
 
       this.lastPlacedSource = null;

--- a/src/Draggable/Plugins/Mirror/Mirror.js
+++ b/src/Draggable/Plugins/Mirror/Mirror.js
@@ -275,7 +275,7 @@ export default class Mirror extends AbstractPlugin {
    * @private
    */
   [onMirrorCreated]({mirror, source, sensorEvent}) {
-    const mirrorClass = this.draggable.getClassNamesFor('mirror');
+    const mirrorClasses = this.draggable.getClassNamesFor('mirror');
 
     const setState = ({mirrorOffset, initialX, initialY, ...args}) => {
       this.mirrorOffset = mirrorOffset;
@@ -292,7 +292,7 @@ export default class Mirror extends AbstractPlugin {
       mirror,
       source,
       sensorEvent,
-      mirrorClass,
+      mirrorClasses,
       scrollOffset: this.scrollOffset,
       options: this.options,
       passedThreshX: true,
@@ -446,18 +446,14 @@ function resetMirror({mirror, source, options, ...args}) {
  * Applys mirror class on mirror element
  * @param {Object} state
  * @param {HTMLElement} state.mirror
- * @param {String|String[]} state.mirrorClass
+ * @param {String[]} state.mirrorClasses
  * @return {Promise}
  * @private
  */
-function addMirrorClasses({mirror, mirrorClass, ...args}) {
+function addMirrorClasses({mirror, mirrorClasses, ...args}) {
   return withPromise((resolve) => {
-    if (mirrorClass instanceof Array) {
-      mirror.classList.add(...mirrorClass);
-    } else {
-      mirror.classList.add(mirrorClass);
-    }
-    resolve({mirror, mirrorClass, ...args});
+    mirror.classList.add(...mirrorClasses);
+    resolve({mirror, mirrorClasses, ...args});
   });
 }
 

--- a/src/Draggable/Plugins/Mirror/Mirror.js
+++ b/src/Draggable/Plugins/Mirror/Mirror.js
@@ -275,7 +275,7 @@ export default class Mirror extends AbstractPlugin {
    * @private
    */
   [onMirrorCreated]({mirror, source, sensorEvent}) {
-    const mirrorClass = this.draggable.getClassNameFor('mirror');
+    const mirrorClass = this.draggable.getClassNamesFor('mirror');
 
     const setState = ({mirrorOffset, initialX, initialY, ...args}) => {
       this.mirrorOffset = mirrorOffset;
@@ -446,13 +446,17 @@ function resetMirror({mirror, source, options, ...args}) {
  * Applys mirror class on mirror element
  * @param {Object} state
  * @param {HTMLElement} state.mirror
- * @param {String} state.mirrorClass
+ * @param {String|String[]} state.mirrorClass
  * @return {Promise}
  * @private
  */
 function addMirrorClasses({mirror, mirrorClass, ...args}) {
   return withPromise((resolve) => {
-    mirror.classList.add(mirrorClass);
+    if (mirrorClass instanceof Array) {
+      mirror.classList.add(...mirrorClass);
+    } else {
+      mirror.classList.add(mirrorClass);
+    }
     resolve({mirror, mirrorClass, ...args});
   });
 }

--- a/src/Draggable/README.md
+++ b/src/Draggable/README.md
@@ -75,6 +75,9 @@ Removes containers from this draggable instance.
 **`draggable.getClassNameFor(name: String): String`**  
 Returns class name for class identifier, check the classes table below for identifiers.
 
+**`draggable.getClassNamesFor(name: String): String[]`**  
+Returns array of class name for class identifier, useful when working with atomic css, check the classes table below for identifiers.
+
 **`draggable.isDragging(): Boolean`**  
 Returns true or false, depending on this draggables dragging state.
 
@@ -117,9 +120,11 @@ plugins controls the mirror movement. Default: `[]`
 Sensors dictate how drag operations get triggered, by listening to native browser events.
 By default draggable includes the `MouseSensor` & `TouchSensor`. Default: `[]`
 
-**`classes {Object}`**  
+**`classes {{String: String|String[]}}`**  
 Draggable adds classes to elements to indicate state. These classes can be used to add styling
-on elements in certain states.
+on elements in certain states. Accept String or Array of strings.
+
+**NOTE**: When specifying multiple classes to an indicate state, the first class MUST be unique for that state to avoid duplicate classes for other states. 
 
 **`exclude {plugins: Plugin[], sensors: Sensor[]}`**  
 Allow excluding default plugins and default sensors. Use with caution as it may create strange behavior.
@@ -156,15 +161,15 @@ Allow excluding default plugins and default sensors. Use with caution as it may 
 
 | Name                 | Description                                                         | Default                            |
 | -------------------- | ------------------------------------------------------------------- | ---------------------------------- |
-| `body:dragging`      | Class added on the document body while dragging                     | `draggable--is-dragging`           |
-| `container:dragging` | Class added on the container where the draggable was picked up from | `draggable-container--is-dragging` |
-| `source:dragging`    | Class added on the draggable element that has been picked up        | `draggable-source--is-dragging`    |
-| `source:placed`      | Class added on the draggable element on `drag:stop`                 | `draggable-source--placed`         |
-| `container:placed`   | Class added on the draggable container element on `drag:stop`       | `draggable-container--placed`      |
-| `draggable:over`     | Class added on draggable element you are dragging over              | `draggable--over`                  |
-| `container:over`     | Class added on draggable container element you are dragging over    | `draggable-container--over`        |
-| `source:original`    | Class added on the original source element, which is hidden on drag | `draggable--original`              |
-| `mirror`             | Class added on the mirror element                                   | `draggable-mirror`                 |
+| `body:dragging`      | Classes added on the document body while dragging                     | `draggable--is-dragging`           |
+| `container:dragging` | Classes added on the container where the draggable was picked up from | `draggable-container--is-dragging` |
+| `source:dragging`    | Classes added on the draggable element that has been picked up        | `draggable-source--is-dragging`    |
+| `source:placed`      | Classes added on the draggable element on `drag:stop`                 | `draggable-source--placed`         |
+| `container:placed`   | Classes added on the draggable container element on `drag:stop`       | `draggable-container--placed`      |
+| `draggable:over`     | Classes added on draggable element you are dragging over              | `draggable--over`                  |
+| `container:over`     | Classes added on draggable container element you are dragging over    | `draggable-container--over`        |
+| `source:original`    | Classes added on the original source element, which is hidden on drag | `draggable--original`              |
+| `mirror`             | Classes added on the mirror element                                   | `draggable-mirror`                 |
 
 ### Example
 
@@ -193,5 +198,18 @@ const draggable = new Draggable(document.querySelectorAll('ul'), {
     plugins: [Draggable.Plugins.Focusable],
     sensors: [Draggable.Sensors.TouchSensor],
   }
+});
+```
+
+Create draggable with specific classes:
+
+```js
+import { Draggable } from '@shopify/draggable';
+
+const draggable = new Draggable(document.querySelectorAll('ul'), {
+  draggable: 'li',
+  classes: {
+    'draggable:over': ['draggable--over', '.bg-red-200', 'bg-opacity-25'],
+  },
 });
 ```

--- a/src/Draggable/README.md
+++ b/src/Draggable/README.md
@@ -124,7 +124,7 @@ By default draggable includes the `MouseSensor` & `TouchSensor`. Default: `[]`
 Draggable adds classes to elements to indicate state. These classes can be used to add styling
 on elements in certain states. Accept String or Array of strings.
 
-**NOTE**: When specifying multiple classes to an indicate state, the first class MUST be unique for that state to avoid duplicate classes for other states. 
+**NOTE**: When specifying multiple classes to an indicate state, the first class MUST be unique for that state to avoid duplicate classes for other states. IE doesn't support add or remove multiple classes. If you want to use multiple classes in IE, you need to add a classList polyfill to your project first.
 
 **`exclude {plugins: Plugin[], sensors: Sensor[]}`**  
 Allow excluding default plugins and default sensors. Use with caution as it may create strange behavior.
@@ -209,7 +209,7 @@ import { Draggable } from '@shopify/draggable';
 const draggable = new Draggable(document.querySelectorAll('ul'), {
   draggable: 'li',
   classes: {
-    'draggable:over': ['draggable--over', '.bg-red-200', 'bg-opacity-25'],
+    'draggable:over': ['draggable--over', 'bg-red-200', 'bg-opacity-25'],
   },
 });
 ```

--- a/src/Draggable/tests/Draggable.test.js
+++ b/src/Draggable/tests/Draggable.test.js
@@ -869,6 +869,50 @@ describe('Draggable', () => {
     expect(draggableElement.classList.contains(newInstance.getClassNameFor('source:original'))).toBeFalsy();
   });
 
+  it('should have multiple classes for `source:original` on start', () => {
+    const sourceOriginalClasses = ['draggable--original', 'class1', 'class2'];
+    const newInstance = new Draggable(containers, {
+      draggable: 'li',
+      classes: {
+        'source:original': sourceOriginalClasses,
+      },
+    });
+    const draggableElement = sandbox.querySelector('li');
+    document.elementFromPoint = () => draggableElement;
+
+    triggerEvent(draggableElement, 'mousedown', {button: 0});
+
+    // Wait for delay
+    waitForDragDelay();
+
+    expect(newInstance.getClassNamesFor('source:original')).toEqual(sourceOriginalClasses);
+
+    triggerEvent(document.body, 'mouseup', {button: 0});
+  });
+
+  it('should removes all draggable classes for `source:original` on stop', () => {
+    const sourceOriginalClasses = ['draggable--original', 'class1', 'class2'];
+    const newInstance = new Draggable(containers, {
+      draggable: 'li',
+      classes: {
+        'source:original': sourceOriginalClasses,
+      },
+    });
+    const draggableElement = sandbox.querySelector('li');
+    document.elementFromPoint = () => draggableElement;
+
+    triggerEvent(draggableElement, 'mousedown', {button: 0});
+
+    // Wait for delay
+    waitForDragDelay();
+
+    triggerEvent(document.body, 'mouseup', {button: 0});
+
+    newInstance.getClassNamesFor('source:original').forEach((className) => {
+      expect(draggableElement.classList).not.toContain(className);
+    });
+  });
+
   it('`drag:out:container` event specifies leaving container', () => {
     const newInstance = new Draggable(containers, {
       draggable: 'li',

--- a/src/Droppable/Droppable.js
+++ b/src/Droppable/Droppable.js
@@ -160,7 +160,7 @@ export default class Droppable extends Draggable {
         continue;
       }
 
-      dropzoneElement.classList.add(this.getClassNameFor('droppable:active'));
+      dropzoneElement.classList.add(...this.getClassNamesFor('droppable:active'));
     }
   }
 
@@ -198,14 +198,14 @@ export default class Droppable extends Draggable {
 
     this.trigger(droppableStopEvent);
 
-    const occupiedClass = this.getClassNameFor('droppable:occupied');
+    const occupiedClasses = this.getClassNamesFor('droppable:occupied');
 
     for (const dropzone of this.dropzones) {
-      dropzone.classList.remove(this.getClassNameFor('droppable:active'));
+      dropzone.classList.remove(...this.getClassNamesFor('droppable:active'));
     }
 
     if (this.lastDropzone && this.lastDropzone !== this.initialDropzone) {
-      this.initialDropzone.classList.remove(occupiedClass);
+      this.initialDropzone.classList.remove(...occupiedClasses);
     }
 
     this.dropzones = null;
@@ -231,14 +231,14 @@ export default class Droppable extends Draggable {
       return false;
     }
 
-    const occupiedClass = this.getClassNameFor('droppable:occupied');
+    const occupiedClasses = this.getClassNamesFor('droppable:occupied');
 
     if (this.lastDropzone) {
-      this.lastDropzone.classList.remove(occupiedClass);
+      this.lastDropzone.classList.remove(...occupiedClasses);
     }
 
     dropzone.appendChild(event.source);
-    dropzone.classList.add(occupiedClass);
+    dropzone.classList.add(...occupiedClasses);
 
     return true;
   }
@@ -261,7 +261,7 @@ export default class Droppable extends Draggable {
     }
 
     this.initialDropzone.appendChild(event.source);
-    this.lastDropzone.classList.remove(this.getClassNameFor('droppable:occupied'));
+    this.lastDropzone.classList.remove(...this.getClassNamesFor('droppable:occupied'));
   }
 
   /**

--- a/src/Plugins/Snappable/Snappable.js
+++ b/src/Plugins/Snappable/Snappable.js
@@ -127,12 +127,12 @@ export default class Snappable extends AbstractPlugin {
       this.mirror.style.display = 'none';
     }
 
-    source.classList.remove(this.draggable.getClassNameFor('source:dragging'));
-    source.classList.add(this.draggable.getClassNameFor('source:placed'));
+    source.classList.remove(...this.draggable.getClassNamesFor('source:dragging'));
+    source.classList.add(...this.draggable.getClassNamesFor('source:placed'));
 
     // Need to cancel this in drag out
     setTimeout(() => {
-      source.classList.remove(this.draggable.getClassNameFor('source:placed'));
+      source.classList.remove(...this.draggable.getClassNamesFor('source:placed'));
     }, this.draggable.options.placedTimeout);
   }
 
@@ -163,7 +163,7 @@ export default class Snappable extends AbstractPlugin {
       this.mirror.style.display = '';
     }
 
-    source.classList.add(this.draggable.getClassNameFor('source:dragging'));
+    source.classList.add(...this.draggable.getClassNamesFor('source:dragging'));
   }
 
   /**


### PR DESCRIPTION
### This PR implements or fixes...

This PR adds the ability to specify an array of classes that gets toggled.

In order to prevent breaking changes, this adds a new method `getClassNamesFor` while keeping the existing behavior of `getClassNameFor` (the former returns an array, and the latter returns the first item of the array).

There's one caveat when using this feature though. Since `classList.contains` only accepts a single class, it's somewhat important that the first class of each DraggableClassNames is unique.

Happy to change whatever needs fixing! I don't use JS too much in my day job, so some fixes might be better made by a maintainer – I ticked the checkbox that allows Draggable maintainers to push to this branch.


### This PR closes the following issues... _(if applicable)_

Fixes #201 (Fun note, the reason I wanted this was also because of Tailwind)


### Does this PR require the Docs to be updated?

A note saying that an array works would probably be useful!


### Does this PR require new tests?

It may be helpful to add a couple! I checked that this didn't break anything, but I didn't add any new ones. Happy to look into this


### This branch been tested on... _(click all that apply / add new items)_

I only tested Sortable in the browser. Does the `examples` directory use the development build?

**Browsers:**

* [x] Chrome 85
* [x] Firefox 80.0.1
* [x] Safari 14
* [ ] IE / Edge _version_
* [x] iOS Safari 13
* [ ] Android Browser _version_
