### PR TITLE
fix(sensor): return early when the target isn't in handle or draggable elements

### DIFF
--- a/jsconfig.json
+++ b/jsconfig.json
@@ -1,0 +1,5 @@
+{
+  "compilerOptions": {
+    "baseUrl": "./src/"
+  }
+}

--- a/src/Draggable/Draggable.js
+++ b/src/Draggable/Draggable.js
@@ -387,7 +387,7 @@ export default class Draggable {
    */
   [onDragStart](event) {
     const sensorEvent = getSensorEvent(event);
-    const {target, container} = sensorEvent;
+    const {target, container, originalSource} = sensorEvent;
 
     if (!this.containers.includes(container)) {
       return;
@@ -398,14 +398,8 @@ export default class Draggable {
       return;
     }
 
-    // Find draggable source element
-    this.originalSource = closest(target, this.options.draggable);
+    this.originalSource = originalSource;
     this.sourceContainer = container;
-
-    if (!this.originalSource) {
-      sensorEvent.cancel();
-      return;
-    }
 
     if (this.lastPlacedSource && this.lastPlacedContainer) {
       clearTimeout(this.placedTimeoutID);

--- a/src/Draggable/Sensors/DragSensor/DragSensor.js
+++ b/src/Draggable/Sensors/DragSensor/DragSensor.js
@@ -80,9 +80,9 @@ export default class DragSensor extends Sensor {
     event.dataTransfer.effectAllowed = this.options.type;
 
     const target = document.elementFromPoint(event.clientX, event.clientY);
-    this.currentContainer = closest(event.target, this.containers);
+    const originalSource = this.draggableElement;
 
-    if (!this.currentContainer) {
+    if (!originalSource) {
       return;
     }
 
@@ -90,6 +90,7 @@ export default class DragSensor extends Sensor {
       clientX: event.clientX,
       clientY: event.clientY,
       target,
+      originalSource,
       container: this.currentContainer,
       originalEvent: event,
     });
@@ -187,6 +188,23 @@ export default class DragSensor extends Sensor {
       return;
     }
 
+    const target = event.target;
+    this.currentContainer = closest(target, this.containers);
+
+    if (!this.currentContainer) {
+      return;
+    }
+
+    if (this.options.handle && target && !closest(target, this.options.handle)) {
+      return;
+    }
+
+    const originalSource = closest(target, this.options.draggable);
+
+    if (!originalSource) {
+      return;
+    }
+
     const nativeDraggableElement = closest(event.target, (element) => element.draggable);
 
     if (nativeDraggableElement) {
@@ -200,17 +218,11 @@ export default class DragSensor extends Sensor {
     document.addEventListener('dragend', this[onDragEnd], false);
     document.addEventListener('drop', this[onDrop], false);
 
-    const target = closest(event.target, this.options.draggable);
-
-    if (!target) {
-      return;
-    }
-
     this.startEvent = event;
 
     this.mouseDownTimeout = setTimeout(() => {
-      target.draggable = true;
-      this.draggableElement = target;
+      originalSource.draggable = true;
+      this.draggableElement = originalSource;
     }, this.delay.drag);
   }
 

--- a/src/Draggable/Sensors/DragSensor/README.md
+++ b/src/Draggable/Sensors/DragSensor/README.md
@@ -22,6 +22,9 @@ Detaches sensors to the DOM
 
 ### Options
 
+**`draggable {String}`**  
+A css selector for draggable elements within the `containers` specified.
+
 **`delay {Number}`**  
 This value will delay touch start
 

--- a/src/Draggable/Sensors/ForceTouchSensor/ForceTouchSensor.js
+++ b/src/Draggable/Sensors/ForceTouchSensor/ForceTouchSensor.js
@@ -1,3 +1,4 @@
+import {closest} from 'shared/utils';
 import Sensor from '../Sensor';
 import {DragStartSensorEvent, DragMoveSensorEvent, DragStopSensorEvent, DragPressureSensorEvent} from '../SensorEvent';
 
@@ -93,11 +94,22 @@ export default class ForceTouchSensor extends Sensor {
     const target = document.elementFromPoint(event.clientX, event.clientY);
     const container = event.currentTarget;
 
+    if (this.options.handle && target && !closest(target, this.options.handle)) {
+      return;
+    }
+
+    const originalSource = closest(target, this.options.draggable);
+
+    if (!originalSource) {
+      return;
+    }
+
     const dragStartEvent = new DragStartSensorEvent({
       clientX: event.clientX,
       clientY: event.clientY,
       target,
       container,
+      originalSource,
       originalEvent: event,
     });
 

--- a/src/Draggable/Sensors/ForceTouchSensor/README.md
+++ b/src/Draggable/Sensors/ForceTouchSensor/README.md
@@ -1,6 +1,6 @@
 ## Force Touch Sensor
 
-__WORK IN PROGRESS__
+**WORK IN PROGRESS**
 
 _Draggable does not use this sensor by default_
 
@@ -26,8 +26,14 @@ Detaches sensors to the DOM
 
 ### Options
 
+**`draggable {String}`**  
+A css selector for draggable elements within the `containers` specified.
+
 **`delay {Number}`**  
 This value will delay force touch start
+
+**`handle {String}`**  
+Specify a css selector for a handle element if you don't want to allow drag action on the entire element.
 
 ### Example
 

--- a/src/Draggable/Sensors/MouseSensor/MouseSensor.js
+++ b/src/Draggable/Sensors/MouseSensor/MouseSensor.js
@@ -83,6 +83,16 @@ export default class MouseSensor extends Sensor {
       return;
     }
 
+    if (this.options.handle && event.target && !closest(event.target, this.options.handle)) {
+      return;
+    }
+
+    const originalSource = closest(event.target, this.options.draggable);
+
+    if (!originalSource) {
+      return;
+    }
+
     const {delay} = this;
     const {pageX, pageY} = event;
 
@@ -91,6 +101,7 @@ export default class MouseSensor extends Sensor {
     this.startEvent = event;
 
     this.currentContainer = container;
+    this.originalSource = originalSource;
     document.addEventListener('mouseup', this[onMouseUp]);
     document.addEventListener('dragstart', preventNativeDragStart);
     document.addEventListener('mousemove', this[onDistanceChange]);
@@ -107,12 +118,14 @@ export default class MouseSensor extends Sensor {
   [startDrag]() {
     const startEvent = this.startEvent;
     const container = this.currentContainer;
+    const originalSource = this.originalSource;
 
     const dragStartEvent = new DragStartSensorEvent({
       clientX: startEvent.clientX,
       clientY: startEvent.clientY,
       target: startEvent.target,
       container,
+      originalSource,
       originalEvent: startEvent,
     });
 

--- a/src/Draggable/Sensors/MouseSensor/README.md
+++ b/src/Draggable/Sensors/MouseSensor/README.md
@@ -22,5 +22,14 @@ Detaches sensors to the DOM
 
 ### Options
 
+**`draggable {String}`**  
+A css selector for draggable elements within the `containers` specified.
+
 **`delay {Number}`**  
-This value will delay touch start
+This value will delay touch start.
+
+**`distance {Number}`**  
+The distance you want the pointer to have moved before drag starts.
+
+**`handle {String}`**  
+Specify a css selector for a handle element if you don't want to allow drag action on the entire element.

--- a/src/Draggable/Sensors/Sensor/README.md
+++ b/src/Draggable/Sensors/Sensor/README.md
@@ -27,5 +27,14 @@ Triggers sensor event on container element
 
 ### Options
 
+**`draggable {String}`**  
+A css selector for draggable elements within the `containers` specified.
+
 **`delay {Number}`**  
-This value will delay drag start
+This value will delay drag start.
+
+**`distance {Number}`**  
+The distance you want the pointer to have moved before drag starts.
+
+**`handle {String}`**  
+Specify a css selector for a handle element if you don't want to allow drag action on the entire element.

--- a/src/Draggable/Sensors/Sensor/Sensor.js
+++ b/src/Draggable/Sensors/Sensor/Sensor.js
@@ -46,6 +46,13 @@ export default class Sensor {
     this.currentContainer = null;
 
     /**
+     * Draggables original source element
+     * @property originalSource
+     * @type {HTMLElement}
+     */
+    this.originalSource = null;
+
+    /**
      * The event of the initial sensor down
      * @property startEvent
      * @type {Event}

--- a/src/Draggable/Sensors/SensorEvent/README.md
+++ b/src/Draggable/Sensors/SensorEvent/README.md
@@ -2,12 +2,12 @@
 
 The base sensor event for all Sensor events that sensors emits.
 
-| | |
-| --------------------- | ---------------------------------------------------------- |
-| **Interface**         | `SensorEvent`                                              |
-| **Cancelable**        | false                                                      |
-| **Cancel action**     | -                                                          |
-| **type**              | `sensor`                                                   |
+|                   |               |
+| ----------------- | ------------- |
+| **Interface**     | `SensorEvent` |
+| **Cancelable**    | false         |
+| **Cancel action** | -             |
+| **type**          | `sensor`      |
 
 ### API
 
@@ -25,55 +25,58 @@ Read-only property for the normalized target for both touch and mouse events.
 Returns the element that is behind cursor or touch pointer.
 
 **`sensorEvent.container: Number`**  
-Read-only property for the container that fired the sensor event
+Read-only property for the container that fired the sensor event.
+
+**`sensorEvent.originalSource: String`**  
+Read-only property for the original source element that was picked up.
 
 **`sensorEvent.pressure: Number`**  
-Read-only property for the pressure applied
+Read-only property for the pressure applied.
 
 ## DragStartSensorEvent
 
 `DragStartSensorEvent` gets triggered by sensors for drag start.
 
-| | |
-| --------------------- | ---------------------------------------------------------- |
-| **Specification**     | `SensorEvent`                                              |
-| **Interface**         | `DragStartSensorEvent`                                     |
-| **Cancelable**        | true                                                       |
-| **Cancel action**     | Prevents drag start                                        |
-| **type**              | `drag:start`                                               |
+|                   |                        |
+| ----------------- | ---------------------- |
+| **Specification** | `SensorEvent`          |
+| **Interface**     | `DragStartSensorEvent` |
+| **Cancelable**    | true                   |
+| **Cancel action** | Prevents drag start    |
+| **type**          | `drag:start`           |
 
 ## DragMoveSensorEvent
 
 `DragMoveSensorEvent` gets triggered by sensors for drag move.
 
-| | |
-| --------------------- | ---------------------------------------------------------- |
-| **Specification**     | `SensorEvent`                                              |
-| **Interface**         | `DragMoveSensorEvent`                                      |
-| **Cancelable**        | false                                                      |
-| **Cancel action**     | -                                                          |
-| **type**              | `drag:move`                                                |
+|                   |                       |
+| ----------------- | --------------------- |
+| **Specification** | `SensorEvent`         |
+| **Interface**     | `DragMoveSensorEvent` |
+| **Cancelable**    | false                 |
+| **Cancel action** | -                     |
+| **type**          | `drag:move`           |
 
 ## DragStopSensorEvent
 
 `DragStopSensorEvent` gets triggered by sensors for drag stop.
 
-| | |
-| --------------------- | ---------------------------------------------------------- |
-| **Specification**     | `SensorEvent`                                              |
-| **Interface**         | `DragStopSensorEvent`                                      |
-| **Cancelable**        | false                                                      |
-| **Cancel action**     | -                                                          |
-| **type**              | `drag:stop`                                                |
+|                   |                       |
+| ----------------- | --------------------- |
+| **Specification** | `SensorEvent`         |
+| **Interface**     | `DragStopSensorEvent` |
+| **Cancelable**    | false                 |
+| **Cancel action** | -                     |
+| **type**          | `drag:stop`           |
 
 ## DragPressureSensorEvent
 
 `DragPressureSensorEvent` gets triggered by sensors for drag pressure.
 
-| | |
-| --------------------- | ---------------------------------------------------------- |
-| **Specification**     | `SensorEvent`                                              |
-| **Interface**         | `DragPressureSensorEvent`                                  |
-| **Cancelable**        | false                                                      |
-| **Cancel action**     | -                                                          |
-| **type**              | `drag:pressure`                                            |
+|                   |                           |
+| ----------------- | ------------------------- |
+| **Specification** | `SensorEvent`             |
+| **Interface**     | `DragPressureSensorEvent` |
+| **Cancelable**    | false                     |
+| **Cancel action** | -                         |
+| **type**          | `drag:pressure`           |

--- a/src/Draggable/Sensors/SensorEvent/SensorEvent.js
+++ b/src/Draggable/Sensors/SensorEvent/SensorEvent.js
@@ -59,6 +59,16 @@ export class SensorEvent extends AbstractEvent {
   }
 
   /**
+   * Draggables original source element
+   * @property originalSource
+   * @type {HTMLElement}
+   * @readonly
+   */
+  get originalSource() {
+    return this.data.originalSource;
+  }
+
+  /**
    * Trackpad pressure
    * @property pressure
    * @type {Number}

--- a/src/Draggable/Sensors/TouchSensor/README.md
+++ b/src/Draggable/Sensors/TouchSensor/README.md
@@ -22,5 +22,14 @@ Detaches sensors to the DOM
 
 ### Options
 
+**`draggable {String}`**  
+A css selector for draggable elements within the `containers` specified.
+
 **`delay {Number}`**  
-This value will delay touch start
+This value will delay touch start.
+
+**`distance {Number}`**  
+The distance you want the pointer to have moved before drag starts.
+
+**`handle {String}`**  
+Specify a css selector for a handle element if you don't want to allow drag action on the entire element.

--- a/src/Draggable/Sensors/TouchSensor/TouchSensor.js
+++ b/src/Draggable/Sensors/TouchSensor/TouchSensor.js
@@ -111,6 +111,17 @@ export default class TouchSensor extends Sensor {
     if (!container) {
       return;
     }
+
+    if (this.options.handle && event.target && !closest(event.target, this.options.handle)) {
+      return;
+    }
+
+    const originalSource = closest(event.target, this.options.draggable);
+
+    if (!originalSource) {
+      return;
+    }
+
     const {distance = 0} = this.options;
     const {delay} = this;
     const {pageX, pageY} = touchCoords(event);
@@ -119,6 +130,7 @@ export default class TouchSensor extends Sensor {
     this.onTouchStartAt = Date.now();
     this.startEvent = event;
     this.currentContainer = container;
+    this.originalSource = originalSource;
 
     document.addEventListener('touchend', this[onTouchEnd]);
     document.addEventListener('touchcancel', this[onTouchEnd]);
@@ -142,12 +154,14 @@ export default class TouchSensor extends Sensor {
     const startEvent = this.startEvent;
     const container = this.currentContainer;
     const touch = touchCoords(startEvent);
+    const originalSource = this.originalSource;
 
     const dragStartEvent = new DragStartSensorEvent({
       clientX: touch.pageX,
       clientY: touch.pageY,
       target: startEvent.target,
       container,
+      originalSource,
       originalEvent: startEvent,
     });
 

--- a/src/Draggable/Sensors/TouchSensor/tests/TouchSensor.test.js
+++ b/src/Draggable/Sensors/TouchSensor/tests/TouchSensor.test.js
@@ -4,8 +4,9 @@ import TouchSensor from '..';
 
 const sampleMarkup = `
   <ul>
-    <li>First item</li>
-    <li>Second item</li>
+    <li class="draggable">First item</li>
+    <li class="draggable">Second item</li>
+    <li class="non-draggable">Non draggable item</li>
   </ul>
 `;
 
@@ -13,11 +14,20 @@ describe('TouchSensor', () => {
   let sandbox;
   let touchSensor;
   let draggableElement;
+  let nonDraggableElement;
 
-  function setup(options = {delay: 0, distance: 0}) {
+  function setup(optionsParam = {}) {
+    const options = {
+      draggable: '.draggable',
+      delay: 0,
+      distance: 0,
+      ...optionsParam,
+    };
+
     sandbox = createSandbox(sampleMarkup);
     const containers = sandbox.querySelectorAll('ul');
-    draggableElement = sandbox.querySelector('li');
+    draggableElement = sandbox.querySelector('.draggable');
+    nonDraggableElement = sandbox.querySelector('.non-draggable');
     touchSensor = new TouchSensor(containers, options);
     touchSensor.attach();
   }
@@ -49,6 +59,8 @@ describe('TouchSensor', () => {
     it('prevents `drag:start` when trying to drag a none draggable element', () => {
       function dragFlow() {
         touchStart(document.body);
+        waitForDragDelay();
+        touchStart(nonDraggableElement);
         waitForDragDelay();
       }
 
@@ -101,7 +113,7 @@ describe('TouchSensor', () => {
 
   describe('using distance', () => {
     beforeEach(() => {
-      setup({delay: 0, distance: 1});
+      setup({distance: 1});
     });
 
     afterEach(teardown);
@@ -157,7 +169,7 @@ describe('TouchSensor', () => {
 
   describe('using delay', () => {
     beforeEach(() => {
-      setup({delay: DRAG_DELAY, distance: 0});
+      setup({delay: DRAG_DELAY});
     });
 
     afterEach(teardown);


### PR DESCRIPTION
### This PR implements or fixes #463

https://codesandbox.io/s/tiptap-prosemirror-draggable-issue-forked-ewp1x

### This PR closes the following issues #463

### Does this PR require the Docs to be updated?

Yes

### Does this PR require new tests?

Yes

### This branch been tested on... _(click all that apply / add new items)_

**Browsers:**

* [x] Chrome
* [x] Firefox
* [x] Safari _version_
* [x] IE / Edge 11
* [x] iOS Browser _version_
* [x] Android Browser _version_
