### PR TITLE
Add `insertBy` option to allow prepending or appending elements

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -397,6 +397,7 @@ declare module '@shopify/draggable' {
     export interface DroppableOptions extends DraggableOptions {
         dropzone: string | NodeList | HTMLElement[] | (() => NodeList | HTMLElement[]);
         classes?: { [key in DroppableClassNames]: string };
+        insertBy: 'prepend' | 'append';
     }
 
     export class Droppable<T = DroppableEventNames> extends Draggable<T> {

--- a/src/Draggable/Draggable.js
+++ b/src/Draggable/Draggable.js
@@ -52,6 +52,7 @@ export const defaultOptions = {
   delay: {},
   distance: 0,
   placedTimeout: 800,
+  insertBy: 'append',
   plugins: [],
   sensors: [],
   exclude: {

--- a/src/Draggable/README.md
+++ b/src/Draggable/README.md
@@ -118,6 +118,10 @@ You can set the same delay for all sensors by setting a number, or set an object
 The distance you want the pointer to have moved before drag starts. This can be useful
 for clickable draggable elements, such as links. Default: `0`
 
+**`insertBy {String}`**  
+The method by which you wish to insert the dragged element. Valid values are `prepend`
+or `append`. Default: `append`
+
 **`plugins {Plugin[]}`**  
 Plugins add behaviour to Draggable by hooking into its life cycle, e.g. one of the default
 plugins controls the mirror movement. Default: `[]`

--- a/src/Droppable/Droppable.js
+++ b/src/Droppable/Droppable.js
@@ -237,7 +237,11 @@ export default class Droppable extends Draggable {
       this.lastDropzone.classList.remove(...occupiedClasses);
     }
 
-    dropzone.appendChild(event.source);
+    if (this.options.insertBy === 'prepend') {
+      dropzone.prepend(event.source);
+    } else {
+      dropzone.appendChild(event.source);
+    }
     dropzone.classList.add(...occupiedClasses);
 
     return true;
@@ -260,7 +264,12 @@ export default class Droppable extends Draggable {
       return;
     }
 
-    this.initialDropzone.appendChild(event.source);
+    if (this.options.insertBy === 'prepend') {
+      this.initialDropzone.prepend(event.source);
+    } else {
+      this.initialDropzone.appendChild(event.source);
+    }
+
     this.lastDropzone.classList.remove(...this.getClassNamesFor('droppable:occupied'));
   }
 


### PR DESCRIPTION
### This PR implements or fixes

This PR allows the user to specify whether they'd like the dragged element to be prepended or appended to the container.
I have a use-case where I need to add the element to the top of a scrollable list of elements, so adding it to the bottom causes it to be below the fold and hence the user can't see it.

### Does this PR require the Docs to be updated?

Yes, and I've done so (hope they're appropriate).

### Does this PR require new tests?

Yes, I've added a default option and added a test for that to ensure backwards compatibility, but it could do with another test to check it actually works. I wasn't able to quickly find a way of doing that, any pointers would be appreciated.

### This branch been tested on... _(click all that apply / add new items)_

**Browsers:**

* [x] Chrome 96.0.4664.55
* [x] Firefox 94.0.2
* [x] Safari 15.1
* [x] IE / Edge 96.0.1054.34
* [ ] iOS Browser _version_
* [ ] Android Browser _version_
