### PR TITLE
Replace `initEvent` with `new CustomEvent`

### DIFF
--- a/scripts/test/helpers/event.js
+++ b/scripts/test/helpers/event.js
@@ -1,8 +1,10 @@
 import {withElementFromPoint} from './environment';
 
 export function triggerEvent(element, type, data = {}) {
-  const event = document.createEvent('Event');
-  event.initEvent(type, true, true);
+  const event = new CustomEvent(type, {
+    bubbles: true,
+    cancelable: true,
+  });
 
   for (const key in data) {
     if (data.hasOwnProperty(key)) {

--- a/src/Draggable/Sensors/Sensor/Sensor.js
+++ b/src/Draggable/Sensors/Sensor/Sensor.js
@@ -107,12 +107,14 @@ export default class Sensor {
    * @param {SensorEvent} sensorEvent - Sensor event to trigger
    */
   trigger(element, sensorEvent) {
-    const event = document.createEvent('Event');
-    event.detail = sensorEvent;
-    event.initEvent(sensorEvent.type, true, true);
+    const event = new CustomEvent(sensorEvent.type, {
+      detail: sensorEvent,
+      bubbles: true,
+      cancelable: true,
+    });
+
     element.dispatchEvent(event);
     this.lastEvent = sensorEvent;
-
     return sensorEvent;
   }
 }


### PR DESCRIPTION
> Thank you for submitting a pull request! Please make sure you have read the [contribution guidelines](https://github.com/Shopify/draggable/blob/master/CONTRIBUTING.md) before proceeding.

### This PR implements or fixes... _(explain your changes)_
Remove deprecated `initEvent` in favor of `new CustomEvent`




### This branch been tested on... _(click all that apply / add new items)_

**Browsers:**

* [x] Chrome _version_
* [x] Firefox _version_
* [ ] Safari _version_
* [ ] IE / Edge _version_
* [ ] iOS Browser _version_
* [x] Android Browser _version_
