### PR TITLE
Do not set fixed (possibly duplicate) ID

### DIFF
--- a/src/Draggable/Plugins/Announcement/Announcement.js
+++ b/src/Draggable/Plugins/Announcement/Announcement.js
@@ -157,7 +157,7 @@ function announce(message, {expire}) {
 function createRegion() {
   const element = document.createElement('div');
 
-  element.setAttribute('id', 'draggable-live-region');
+  element.classList.add('draggable-live-region');
   element.setAttribute(ARIA_RELEVANT, 'additions');
   element.setAttribute(ARIA_ATOMIC, 'true');
   element.setAttribute(ARIA_LIVE, 'assertive');


### PR DESCRIPTION
introduced in https://github.com/Shopify/draggable/pull/102, the div can exists multiple times with the same ID in the DOM

please merge & release asap, this problem is failing our CI where we assert no duplicate ID across all tested pages