### PR TITLE
Handle case when element is undefined

### DIFF
--- a/src/Plugins/SwapAnimation/SwapAnimation.ts
+++ b/src/Plugins/SwapAnimation/SwapAnimation.ts
@@ -120,8 +120,9 @@ function animate(
   to: HTMLElement,
   {duration, easingFunction, horizontal}: Options,
 ) {
+ 
   for (const element of [from, to]) {
-    element.style.pointerEvents = 'none';
+    element?.style.pointerEvents = 'none';
   }
 
   if (horizontal) {
@@ -136,9 +137,9 @@ function animate(
 
   requestAnimationFrame(() => {
     for (const element of [from, to]) {
-      element.addEventListener('transitionend', resetElementOnTransitionEnd);
-      element.style.transition = `transform ${duration}ms ${easingFunction}`;
-      element.style.transform = '';
+      element?.addEventListener('transitionend', resetElementOnTransitionEnd);
+      element?.style.transition = `transform ${duration}ms ${easingFunction}`;
+      element?.style.transform = '';
     }
   });
 }


### PR DESCRIPTION
 ### This PR implements or fixes...

This prevents an error in a case when dragging elements to an empty container.  In those cases, the element ends up being undefined throwing an error. I thought the easiest way to fix would be just using optional chaining.

<img width="918" alt="Screenshot 2023-12-14 at 5 12 08 PM" src="https://github.com/Shopify/draggable/assets/308134/d0682e47-f10e-40d3-af14-d44e70aa12c1">

### Does this PR require the Docs to be updated?

No

### Does this PR require new tests?

No

### This branch been tested on... _(click all that apply / add new items)_

**Browsers:**

- [ x] Chrome _version_
- [ ] Firefox _version_
- [ ] Safari _version_
- [ ] IE / Edge _version_
- [ ] iOS Browser _version_
- [ ] Android Browser _version_
