### PR TITLE
Prevent simultaneous dragging

### DIFF
--- a/src/Draggable/Draggable.js
+++ b/src/Draggable/Draggable.js
@@ -420,6 +420,10 @@ export default class Draggable {
    * @param {Event} event - DOM Drag event
    */
   [onDragStart](event) {
+    if (this.dragging) {
+      return;
+    }
+
     const sensorEvent = getSensorEvent(event);
     const {target, container, originalSource} = sensorEvent;
 

--- a/src/Droppable/Droppable.js
+++ b/src/Droppable/Droppable.js
@@ -143,7 +143,7 @@ export default class Droppable extends Draggable {
    * @param {DragStartEvent} event - Drag start event
    */
   [onDragStart](event) {
-    if (event.canceled()) {
+    if (event.canceled() || this.isDragging()) {
       return;
     }
 

--- a/src/Sortable/Sortable.js
+++ b/src/Sortable/Sortable.js
@@ -150,6 +150,10 @@ export default class Sortable extends Draggable {
    * @param {DragStartEvent} event - Drag start event
    */
   [onDragStart](event) {
+    if (this.isDragging()) {
+      return;
+    }
+
     this.startContainer = event.source.parentNode;
     this.startIndex = this.index(event.source);
 

--- a/src/Swappable/Swappable.js
+++ b/src/Swappable/Swappable.js
@@ -93,6 +93,10 @@ export default class Swappable extends Draggable {
    * @param {DragStartEvent} event - Drag start event
    */
   [onDragStart](event) {
+    if (this.isDragging()) {
+      return;
+    }
+
     const swappableStartEvent = new SwappableStartEvent({
       dragEvent: event,
     });


### PR DESCRIPTION


<!-- Thank you for submitting a pull request! Please make sure you have read the [contribution guidelines](https://github.com/Shopify/draggable/blob/main/CONTRIBUTING.md) before proceeding. -->

### This PR implements or fixes...

Prior to this change, if a user dragged two draggable elements at the same time, we would get into a bad state. Elements and classes would not be cleaned up and drag:stop would never fire.

### Does this PR require the Docs to be updated?

Nope

### Does this PR require new tests?

I didn't add any.

### This branch been tested on... _(click all that apply / add new items)_

**Browsers:**

- [ ] Chrome _version_
- [X] Firefox 136
- [ ] Safari _version_
- [ ] IE / Edge _version_
- [ ] iOS Browser _version_
- [ ] Android Browser _version_
