### PR TITLE
Fix ResizeMirror missing mirror:destroy listener in attach()

### DIFF
--- a/.changeset/resizemirror-destroy-listener.md
+++ b/.changeset/resizemirror-destroy-listener.md
@@ -1,0 +1,5 @@
+---
+'@shopify/draggable': patch
+---
+
+Fix `ResizeMirror` not registering its `mirror:destroy` listener in `attach()`. The listener was removed in `detach()` but never bound, so the internal `mirror` reference was never cleared between drags. The companion `Snappable` plugin already binds both `mirror:created` and `mirror:destroy`; this restores symmetry.

--- a/src/Plugins/ResizeMirror/ResizeMirror.ts
+++ b/src/Plugins/ResizeMirror/ResizeMirror.ts
@@ -61,6 +61,7 @@ export default class ResizeMirror extends AbstractPlugin {
   attach() {
     this.draggable
       .on('mirror:created', this.onMirrorCreated)
+      .on('mirror:destroy', this.onMirrorDestroy)
       .on('drag:over', this.onDragOver)
       .on('drag:over:container', this.onDragOver);
   }


### PR DESCRIPTION
The `ResizeMirror` plugin's `attach()` method registers `mirror:created`, `drag:over`, and `drag:over:container` listeners but does not register a `mirror:destroy` listener. The corresponding `detach()` method does call `.off('mirror:destroy', this.onMirrorDestroy)`, so the asymmetry looks like an oversight from the original implementation.

The practical effect is that `this.mirror` is never reset to `null` between drags via the destroy event. Today the plugin still works because `resize()` early-returns when `this.mirror.parentNode == null`, but the plugin holds a reference to a detached mirror element until the next `mirror:created` fires, and the `onMirrorDestroy` method is effectively dead code without this binding.

The companion `Snappable` plugin already binds both `mirror:created` and `mirror:destroy` in its `attach()`. This change makes `ResizeMirror` consistent with that pattern and with its own `detach()`.

A changeset is included. Existing tests pass (`yarn test`, `yarn type-check`, `yarn lint` all clean).